### PR TITLE
fix(gitea-runner): bump VolSync cacheCapacity from 4Gi to 8Gi

### DIFF
--- a/clusters/omv/apps/20-applications.yaml
+++ b/clusters/omv/apps/20-applications.yaml
@@ -92,7 +92,7 @@ applications:
           - name: VOLSYNC_CAPACITY
             value: 2Gi
           - name: VOLSYNC_CACHE_CAPACITY
-            value: 4Gi
+            value: 8Gi
 
   rancher:
     annotations:


### PR DESCRIPTION
## Problem

`VolSyncVolumeOutOfSync` critical alert firing for `default/gitea-runner` on omv cluster.

The VolSync ReplicationSource cache PVC has already grown to 8Gi, but `VOLSYNC_CACHE_CAPACITY` is set to 4Gi. Since PVCs cannot shrink, the spec mismatch causes VolSync replication to fail.

## Fix

Bumped `VOLSYNC_CACHE_CAPACITY` from `4Gi` to `8Gi` in `clusters/omv/apps/20-applications.yaml` to match the actual cache PVC size.

## Impact

VolSync replication for gitea-runner will resume on next sync cycle.