### PR TITLE
fix(rancher): increase startup probe threshold and add resource requests

### DIFF
--- a/components/cattle-system/rancher/helm-chart.yaml
+++ b/components/cattle-system/rancher/helm-chart.yaml
@@ -19,6 +19,14 @@ spec:
       enabled: false
     tls: external
     agentTLSMode: "system-store"
+    startupProbe:
+      failureThreshold: 24
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 1536Mi
     extraEnv:
       - name: CATTLE_FEATURES
         value: "fleet=false"


### PR DESCRIPTION
## Alert
KubeAggregatedAPIDown firing — `v1.ext.cattle.io` only 63.64% available over 10m.

## Root Cause
Rancher pod fails startup probes (default 120s too short on slower nodes). Pod gets killed before it finishes initializing, which takes down the aggregated API endpoint.

## Fix
- **startupProbe.failureThreshold: 24** — extends the startup window from ~120s to ~240s
- **Resource requests** (250m CPU, 512Mi memory) — prevents BestEffort QoS starvation which can compound the slow startup
- **Memory limit** (1536Mi) — guards against runaway memory usage

1 file changed: `components/cattle-system/rancher/helm-chart.yaml`