### PR TITLE
feat: wire Sonos IPs into Hermes

### DIFF
--- a/components/ai/hermes-agent/externalsecret.yaml
+++ b/components/ai/hermes-agent/externalsecret.yaml
@@ -28,6 +28,7 @@ spec:
         TAVILY_API_KEY: "{{ .TAVILY_API_KEY }}"
         IVAN_PERSONAL_SERVICE_URL: http://ivan-personal-service.ai.svc.cluster.local:8080
         IVAN_PERSONAL_API_KEY: "{{ .IVAN_PERSONAL_API_KEY }}"
+        SONOS_SPEAKER_IPS: "{{ .SONOS_SPEAKER_IPS }}"
         .env: |-
           HERMES_API_KEY={{ .INFERENCE_HUB_API_KEY }}
           HERMES_BASE_URL={{ .INFERENCE_HUB_BASE_URL }}
@@ -37,6 +38,7 @@ spec:
           GOG_KEYRING_BACKEND=file
           IVAN_PERSONAL_SERVICE_URL=http://ivan-personal-service.ai.svc.cluster.local:8080
           IVAN_PERSONAL_API_KEY={{ .IVAN_PERSONAL_API_KEY }}
+          SONOS_SPEAKER_IPS={{ .SONOS_SPEAKER_IPS }}
   dataFrom:
     - extract:
         key: inference-hub

--- a/docs/runbooks/hermes-sonos.md
+++ b/docs/runbooks/hermes-sonos.md
@@ -1,0 +1,68 @@
+# Hermes Sonos speaker IPs
+
+Hermes receives Sonos speaker addresses from `SONOS_SPEAKER_IPS`, a comma-separated list supplied by the `hermes-agent-secret` Kubernetes Secret. The secret is rendered by External Secrets from the `hermes` 1Password item, so speaker IPs stay out of Git.
+
+The `sonos` CLI can target a speaker directly with `--ip`; it does not currently read `SONOS_SPEAKER_IPS` by itself. Treat the variable as the Hermes-side inventory of known, routable speakers that agents/operators can use when multicast discovery is unreliable.
+
+## Update or rotate speaker IPs
+
+1. Update the `SONOS_SPEAKER_IPS` field in the `hermes` item in the 1Password vault used by the `onepassword-connect` ClusterSecretStore.
+   - Format: comma-separated IP addresses, with no spaces required, for example `<speaker-ip>,<speaker-ip>`.
+   - Include only Sonos devices reachable from the Hermes pod network on TCP port 1400.
+   - Confirm the field exists before syncing this GitOps change; External Secrets will fail to render `hermes-agent-secret` if the template references a missing field.
+   - Do not commit real speaker IPs to this repository.
+2. Wait for External Secrets to reconcile, or force a refresh if you are operating the cluster manually.
+3. Confirm `hermes-agent-secret` was updated in the `ai` namespace.
+4. Reloader should restart the Hermes deployment because `components/ai/hermes-agent/values.yaml` annotates the controller with `secret.reloader.stakater.com/reload: hermes-agent-secret`.
+
+## Verify in Kubernetes
+
+```bash
+kubectl -n ai get externalsecret hermes-agent
+kubectl -n ai get secret hermes-agent-secret -o jsonpath='{.data.SONOS_SPEAKER_IPS}' | wc -c
+kubectl -n ai exec deploy/hermes-agent -c app -- sh -c 'test -n "$SONOS_SPEAKER_IPS"'
+```
+
+These commands confirm that the ExternalSecret exists, the Secret key has a value, and the Hermes pod receives the environment variable without printing the actual IP list.
+
+If you need to inspect the exact value during a rotation, decode it explicitly:
+
+```bash
+kubectl -n ai get secret hermes-agent-secret -o jsonpath='{.data.SONOS_SPEAKER_IPS}' | base64 -d
+```
+
+The decoded value should be the comma-separated list from 1Password. Treat it as sensitive and avoid pasting it into logs, tickets, or commits.
+
+## Verify Hermes/Sonos behavior
+
+From a Hermes session with the Sonos skill/tool available, run read-only checks first. Multicast discovery may work when Hermes and Sonos are on the same L2 network:
+
+```bash
+sonos discover --format json
+sonos group status --format json
+```
+
+If discovery is unreliable or blocked, verify one of the configured IPs directly:
+
+```bash
+sonos status --ip "<speaker-ip>" --format json
+```
+
+Then inspect a named speaker if discovery returns expected rooms:
+
+```bash
+sonos status --name "<room name>" --format json
+```
+
+Only run playback, volume, grouping, queue, or favorite commands after explicit user confirmation.
+
+## GitOps validation
+
+Before opening a PR, validate the changed manifests:
+
+```bash
+kustomize build --load-restrictor=LoadRestrictionsNone --enable-helm components/ai/hermes-agent >/dev/null
+./scripts/kubeconform.sh
+```
+
+This environment may not have `kubectl`, `kustomize`, `helm`, or `kubeconform` installed, so run the commands from an operator workstation or CI environment when local tools are unavailable.


### PR DESCRIPTION
## Summary
- Add `SONOS_SPEAKER_IPS` to the Hermes ExternalSecret template and generated `.env` payload.
- Rely on the existing `hermes-agent-secret` `envFrom` wiring and reloader annotation to inject/restart Hermes without committing plaintext IPs.
- Add a Sonos runbook covering 1Password rotation, safe verification, direct `--ip` checks, and GitOps validation.

## Verification
- `git diff --cached --check`
- Python YAML parse and semantic checks for Hermes ExternalSecret/envFrom/reloader wiring
- Scanned staged additions for literal IPv4s: none found
- In-cluster Kubernetes API inspection attempted from the pod, but the `ai:default` service account is forbidden from reading ExternalSecrets/Deployments/Secrets
- `kustomize`, `kubectl`, `helm`, and `kubeconform` are not installed in this worker environment, so full render/schema checks should run in CI or from an operator workstation

## Review
- OpenCode review: no blocking issues
- Independent Hermes reviewer: approved; no blocking issues
