### PR TITLE
feat(gitea): enable Pages + pages.omv.a113.casa HTTPRoute

### DIFF
--- a/components/default/gitea/http-route-pages.yaml
+++ b/components/default/gitea/http-route-pages.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gitea-pages
+  labels:
+    app.kubernetes.io/instance: gitea
+    app.kubernetes.io/name: gitea
+spec:
+  parentRefs:
+    - name: ${GATEWAY_NAME}
+      namespace: ${GATEWAY_NAMESPACE}
+      sectionName: https
+  hostnames: ["pages.${CLUSTER_DOMAIN}"]
+  rules:
+    - backendRefs:
+        - name: gitea
+          port: 3000

--- a/components/default/gitea/kustomization.yaml
+++ b/components/default/gitea/kustomization.yaml
@@ -6,6 +6,7 @@ components:
 resources:
   - ./external-secret.yaml
   - ./http-route.yaml
+  - ./http-route-pages.yaml
 
 helmCharts:
   - name: app-template

--- a/components/default/gitea/values.yaml
+++ b/components/default/gitea/values.yaml
@@ -34,6 +34,7 @@ controllers:
           GITEA__SERVER__ROOT_URL: "https://gitea.${CLUSTER_DOMAIN}"
           GITEA__SERVER__SSH_DOMAIN: "ssh.${CLUSTER_DOMAIN}"
           GITEA__SERVER__SSH_PORT: 2222
+          GITEA__SERVER__PAGES_DOMAIN: "pages.${CLUSTER_DOMAIN}"
         securityContext:
           allowPrivilegeEscalation: false
           # mkdir: can't create directory '/tmp/gitea': Read-only file system


### PR DESCRIPTION
## What

Enable Gitea Pages so repos with a `gh-pages` branch are served as static sites.

## Changes

- `values.yaml`: add `GITEA__SERVER__PAGES_DOMAIN: pages.${CLUSTER_DOMAIN}`
- `http-route-pages.yaml`: new HTTPRoute routing `pages.omv.a113.casa` → `gitea:3000`
- `kustomization.yaml`: register the new HTTPRoute

## After merge

`ai-zero-to-hero` (already has a `gh-pages` branch) will be live at:
**https://pages.omv.a113.casa/vpogu/ai-zero-to-hero**

Any future repo with a `gh-pages` branch works the same way.