### PR TITLE
feat(ai): add agent-sandbox CRD controller deployment

### DIFF
--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -518,6 +518,14 @@ applications:
     source:
       path: components/ai/ivan-dashboard
 
+  agent-sandbox:
+    annotations:
+      argocd.argoproj.io/sync-wave: "05"
+    destination:
+      namespace: agent-sandbox-system
+    source:
+      path: components/ai/agent-sandbox
+
   holmesgpt:
     annotations:
       argocd.argoproj.io/sync-wave: "20"

--- a/components/ai/agent-sandbox/kustomization.yaml
+++ b/components/ai/agent-sandbox/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: agent-sandbox-system
+resources:
+  - https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/manifest.yaml


### PR DESCRIPTION
## Context

Part of the Forge autonomous dev loop deployment. This is the first prerequisite — the Agent Sandbox CRD controller must be installed before OpenShell can run sandbox pods.

## What this does

Installs the `kubernetes-sigs/agent-sandbox` controller, which provides the `Sandbox` CRD (`agents.x-k8s.io/v1alpha1`) used by OpenShell to provision sandbox pods on Kubernetes.

### Changes

- **`components/ai/agent-sandbox/kustomization.yaml`** — new Kustomization pulling the upstream `manifest.yaml` from the latest agent-sandbox release into the `agent-sandbox-system` namespace.
- **`clusters/talos/apps/20-applications.yaml`** — new `agent-sandbox` ArgoCD Application entry at sync-wave `05` so it deploys before OpenShell. Placed near the top of the ai section, before `holmesgpt`.

### Notes

- `CreateNamespace=false` is set globally. The upstream agent-sandbox manifest creates its own `agent-sandbox-system` namespace, so no separate `namespace.yaml` is required.
- Both files validated with `yamllint -d relaxed`.