### PR TITLE
feat: add OpenShell Gateway deployment

### DIFF
--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -502,6 +502,14 @@ applications:
           - name: VOLSYNC_CACHE_CAPACITY
             value: 8Gi
 
+  openshell:
+    annotations:
+      argocd.argoproj.io/sync-wave: "10"
+    destination:
+      namespace: openshell
+    source:
+      path: components/ai/openshell
+
   ivan-personal-service:
     annotations:
       argocd.argoproj.io/sync-wave: "20"

--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -506,7 +506,7 @@ applications:
     annotations:
       argocd.argoproj.io/sync-wave: "10"
     destination:
-      namespace: openshell
+      namespace: ai
     source:
       path: components/ai/openshell
 

--- a/components/ai/openshell/externalsecret.yaml
+++ b/components/ai/openshell/externalsecret.yaml
@@ -3,7 +3,7 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: openshell-db
-  namespace: openshell
+  namespace: ai
 spec:
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/ai/openshell/externalsecret.yaml
+++ b/components/ai/openshell/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openshell-db
+  namespace: openshell
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: openshell-db-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        uri: >-
+          postgres://{{ .OPENSHELL_POSTGRES_USER }}:{{ .OPENSHELL_POSTGRES_PASS }}@postgres17-rw.default.svc.cluster.local:5432/openshell
+        INIT_POSTGRES_DBNAME: openshell
+        INIT_POSTGRES_HOST: postgres17-rw.default.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .OPENSHELL_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .OPENSHELL_POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: openshell
+    - extract:
+        key: cloudnative-pg

--- a/components/ai/openshell/kustomization.yaml
+++ b/components/ai/openshell/kustomization.yaml
@@ -1,16 +1,15 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: ai
 resources:
   - ./sandbox-namespace.yaml
   - ./externalsecret.yaml
 
 helmCharts:
-  - name: openshell
+  - name: helm-chart
     releaseName: openshell
     namespace: ai
-    repo: oci://ghcr.io/nvidia/openshell/helm-chart
+    repo: oci://ghcr.io/nvidia/openshell
     version: "0.0.0-dev"
     valuesFile: values.yaml
     includeCRDs: false

--- a/components/ai/openshell/kustomization.yaml
+++ b/components/ai/openshell/kustomization.yaml
@@ -1,16 +1,15 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openshell
+namespace: ai
 resources:
-  - ./namespace.yaml
   - ./sandbox-namespace.yaml
   - ./externalsecret.yaml
 
 helmCharts:
   - name: openshell
     releaseName: openshell
-    namespace: openshell
+    namespace: ai
     repo: oci://ghcr.io/nvidia/openshell/helm-chart
     version: "0.0.0-dev"
     valuesFile: values.yaml

--- a/components/ai/openshell/kustomization.yaml
+++ b/components/ai/openshell/kustomization.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshell
+resources:
+  - ./namespace.yaml
+  - ./sandbox-namespace.yaml
+  - ./externalsecret.yaml
+
+helmCharts:
+  - name: openshell
+    releaseName: openshell
+    namespace: openshell
+    repo: oci://ghcr.io/nvidia/openshell/helm-chart
+    version: "0.0.0-dev"
+    valuesFile: values.yaml
+    includeCRDs: false

--- a/components/ai/openshell/namespace.yaml
+++ b/components/ai/openshell/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshell

--- a/components/ai/openshell/namespace.yaml
+++ b/components/ai/openshell/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshell

--- a/components/ai/openshell/sandbox-namespace.yaml
+++ b/components/ai/openshell/sandbox-namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshell-sandboxes
+  labels:
+    openshell.io/sandbox-namespace: "true"

--- a/components/ai/openshell/values.yaml
+++ b/components/ai/openshell/values.yaml
@@ -1,0 +1,31 @@
+replicaCount: 1
+
+workload:
+  kind: Deployment
+
+server:
+  sandboxNamespace: openshell-sandboxes
+  sandboxImage: ghcr.io/nvidia/openshell/sandbox:latest
+  supervisorImage: ghcr.io/nvidia/openshell/supervisor:latest
+  appArmorProfile: Unconfined
+  externalDbSecret: openshell-db-secret
+  auth:
+    allowUnauthenticatedUsers: false
+  disableTls: false
+  grpcEndpoint: openshell.openshell.svc.cluster.local:9090
+
+image:
+  repository: ghcr.io/nvidia/openshell/gateway
+  tag: latest
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+service:
+  type: ClusterIP
+  port: 8080

--- a/components/ai/openshell/values.yaml
+++ b/components/ai/openshell/values.yaml
@@ -12,7 +12,7 @@ server:
   auth:
     allowUnauthenticatedUsers: false
   disableTls: false
-  grpcEndpoint: openshell.openshell.svc.cluster.local:9090
+  grpcEndpoint: openshell.ai.svc.cluster.local:9090
 
 image:
   repository: ghcr.io/nvidia/openshell/gateway


### PR DESCRIPTION
## Summary

Adds the **OpenShell Gateway** Helm chart deployment as part of the Forge autonomous dev loop. This is the second piece — deployed into the cluster via ArgoCD app-of-apps.

**Depends on:** the `agent-sandbox` CRD PR — OpenShell requires the agent-sandbox CRD to be installed first (CRDs are intentionally excluded here via `includeCRDs: false`). These PRs merge sequentially.

## What's included

Creates `components/ai/openshell/` with 5 files:

- `kustomization.yaml` — Helm chart from `oci://ghcr.io/nvidia/openshell/helm-chart`, `includeCRDs: false`
- `namespace.yaml` — `openshell` namespace (created explicitly; `CreateNamespace=false` is global)
- `sandbox-namespace.yaml` — `openshell-sandboxes` namespace where sandbox pods run
- `externalsecret.yaml` — DB secret from 1Password (`onepassword-connect` ClusterSecretStore), init-db pattern against `postgres17-rw.default.svc.cluster.local`
- `values.yaml` — `Deployment` workload (external Postgres), `appArmorProfile: Unconfined` (Talos AppArmor conflict), mTLS auth, ClusterIP service

Adds `openshell` to `clusters/talos/apps/20-applications.yaml` at sync-wave `"10"` (after agent-sandbox at `"05"`, before the `ai` apps at `"20"`).

No HTTPRoute — the Forge orchestrator calls it in-cluster via `http://openshell.openshell.svc.cluster.local:8080`.

## ⚠️ Pre-step (manual, required before syncing ArgoCD)

⚠️ Pre-step: Create `openshell` item in 1Password with keys `OPENSHELL_POSTGRES_USER` and `OPENSHELL_POSTGRES_PASS` before syncing ArgoCD

The `cloudnative-pg` 1Password item already provides `POSTGRES_SUPER_PASS`.
