### PR TITLE
fix(hermes-agent): add drop_pending_updates to Telegram config

### DIFF
--- a/components/ai/hermes-agent/configmap.yaml
+++ b/components/ai/hermes-agent/configmap.yaml
@@ -218,6 +218,10 @@ data:
         - web/ddgs
         - security-guidance
         - observability/langfuse
+    platforms:
+      telegram:
+        extra:
+          drop_pending_updates: true
     platform_toolsets:
       cli:
         - browser


### PR DESCRIPTION
## Context

Hermes sends duplicate Telegram messages after every pod rollout. When the hermes-agent pod restarts, Telegram retries all unacknowledged webhook updates from the downtime window. Hermes processes each retry as a new message, sending the same response multiple times.

## Fix

Add `drop_pending_updates: true` to the Telegram platform config in the hermes-agent ConfigMap. This tells Telegram to discard queued updates on startup so only fresh messages are processed.

This change is already applied to the live `/opt/data/config.yaml` on the PVC. This PR makes it permanent so it survives pod rebuilds.

## Change

```yaml
    platforms:
      telegram:
        extra:
          drop_pending_updates: true
```

Validated with `yamllint -d relaxed components/ai/hermes-agent/configmap.yaml`.