### PR TITLE
Allow OpenShell sandbox pods through PSA

### DIFF
--- a/components/ai/openshell/sandbox-namespace.yaml
+++ b/components/ai/openshell/sandbox-namespace.yaml
@@ -5,3 +5,4 @@ metadata:
   name: openshell-sandboxes
   labels:
     openshell.io/sandbox-namespace: "true"
+    pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
## Why
OpenShell Sandbox resources were created, but the agent-sandbox controller could not create their Pods because `openshell-sandboxes` inherited the Talos cluster-wide Pod Security Admission `baseline` policy. The generated sandbox pod requires AppArmor `Unconfined` plus `NET_ADMIN`, `SYSLOG`, `SYS_ADMIN`, and `SYS_PTRACE`.

## Change
Add a namespace-scoped `pod-security.kubernetes.io/enforce: privileged` label to `openshell-sandboxes`.

## Security boundary
`privileged` removes all Pod Security Admission restrictions for workloads in this dedicated sandbox namespace. It does not grant RBAC permissions. The namespace must remain exclusive to the OpenShell controller; do not grant unrelated users or workloads Pod/Sandbox creation there. Existing network policies are ingress-only, so sandbox egress remains a separate hardening concern.

## Verification
- `kubeconform -strict components/ai/openshell/sandbox-namespace.yaml`
- Rendered OpenShell Namespace asserts `pod-security.kubernetes.io/enforce == privileged`
- Rendered OpenShell manifests pass strict kubeconform with repository schema skips
- `kubectl apply --dry-run=server -f components/ai/openshell/sandbox-namespace.yaml`
