### PR TITLE
feat: isolate Gitea runner burst capacity

### DIFF
--- a/.github/workflows/kubeconform.yml
+++ b/.github/workflows/kubeconform.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - "components/**"
       - "clusters/**"
+      - "scripts/**"
+      - ".github/workflows/kubeconform.yml"
   issue_comment:
     types: [created]
 
@@ -44,7 +46,7 @@ jobs:
 
       - name: Setup Workflow Tools
         shell: bash
-        run: brew install kubernetes-cli kustomize gettext
+        run: brew install kubernetes-cli kustomize gettext helm yq
 
       - name: Setup kubeconform
         shell: bash
@@ -55,3 +57,7 @@ jobs:
       - name: Run kubeconform
         shell: bash
         run: bash ./scripts/kubeconform.sh
+
+      - name: Run Gitea runner pool contract test
+        shell: bash
+        run: bash ./scripts/test-gitea-runner-pool-rendered-manifest.sh

--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -159,6 +159,26 @@ applications:
           - name: VOLSYNC_SCHEDULE
             value: "40 */6 * * *"
 
+  gitea-runner-burst:
+    annotations:
+      argocd.argoproj.io/sync-wave: "20"
+    destination:
+      namespace: default
+    source:
+      path: components/default/gitea-runner-burst
+      plugin:
+        env:
+          - name: STORAGE_CLASS
+            value: ceph-block
+          - name: VOLUME_SNAPSHOT_CLASS
+            value: csi-ceph-blockpool
+          - name: VOLSYNC_CAPACITY
+            value: 2Gi
+          - name: VOLSYNC_CACHE_CAPACITY
+            value: 8Gi
+          - name: VOLSYNC_SCHEDULE
+            value: "40 */6 * * *"
+
   ntfy:
     annotations:
       argocd.argoproj.io/sync-wave: "20"

--- a/components/default/gitea-runner-burst/configmap.yaml
+++ b/components/default/gitea-runner-burst/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gitea-runner-config
+  name: gitea-runner-burst-config
 data:
   config.yaml: |
     log:
@@ -10,7 +10,7 @@ data:
 
     runner:
       file: /data/.runner
-      capacity: 2
+      capacity: 1
       timeout: 3h
       insecure: false
       fetch_timeout: 5s

--- a/components/default/gitea-runner-burst/external-secret.yaml
+++ b/components/default/gitea-runner-burst/external-secret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitea-runner-burst
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gitea-runner-burst-secret
+    template:
+      engineVersion: v2
+      data:
+        GITEA_RUNNER_REGISTRATION_TOKEN: "{{ .RUNNER_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: gitea

--- a/components/default/gitea-runner-burst/kustomization.yaml
+++ b/components/default/gitea-runner-burst/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../volsync-system/volsync-replication
+resources:
+  - ./external-secret.yaml
+  - ./configmap.yaml
+  - ./pvc-docker.yaml
+
+helmCharts:
+  - name: app-template
+    releaseName: gitea-runner-burst
+    namespace: default
+    repo: oci://ghcr.io/bjw-s-labs/helm
+    version: "5.0.1"
+    valuesFile: values.yaml

--- a/components/default/gitea-runner-burst/pvc-docker.yaml
+++ b/components/default/gitea-runner-burst/pvc-docker.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gitea-runner-burst-docker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 100Gi

--- a/components/default/gitea-runner-burst/values.yaml
+++ b/components/default/gitea-runner-burst/values.yaml
@@ -1,0 +1,80 @@
+---
+controllers:
+  app:
+    replicas: 1
+    strategy: Recreate
+    annotations:
+      reloader.stakater.com/auto: "true"
+    containers:
+      runner:
+        image:
+          repository: gitea/act_runner
+          tag: 0.6.1@sha256:b5c35d6bdbb9bb25e531230bfc7cc663cb751406cbec90a2a891b85fea54de86
+        command:
+          - sh
+          - -c
+          - |
+            while ! nc -z localhost 2375 </dev/null; do
+              echo 'waiting for docker daemon...'
+              sleep 5
+            done
+            /sbin/tini -- run.sh
+        env:
+          DOCKER_HOST: tcp://localhost:2375
+          GITEA_INSTANCE_URL: "https://gitea.${CLUSTER_DOMAIN}"
+          GITEA_RUNNER_LABELS: "ubuntu-latest:docker://docker.gitea.com/runner-images:ubuntu-24.04,ubuntu-24.04:docker://docker.gitea.com/runner-images:ubuntu-24.04,ubuntu-22.04:docker://docker.gitea.com/runner-images:ubuntu-22.04"
+          CONFIG_FILE: /config/config.yaml
+        envFrom:
+          - secretRef:
+              name: gitea-runner-burst-secret
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+      daemon:
+        image:
+          repository: docker
+          tag: dind
+        env:
+          DOCKER_TLS_CERTDIR: ""
+        securityContext:
+          # Standard (root) Docker-in-Docker. dockerd needs full privileges to
+          # manage cgroups, the bridge network and overlayfs for image builds,
+          # so the daemon runs privileged. Isolation is at the node level only;
+          # Kata VM sandboxing was ruled out (incompatible with this cluster's
+          # Cilium netkit-L3 datapath — kata-containers/kata-containers#12159).
+          privileged: true
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+
+persistence:
+  docker-certs:
+    enabled: true
+    type: emptyDir
+    globalMounts:
+      - path: /certs
+  docker-data:
+    enabled: true
+    existingClaim: gitea-runner-burst-docker
+    advancedMounts:
+      app:
+        daemon:
+          - path: /var/lib/docker
+  config:
+    enabled: true
+    type: configMap
+    name: gitea-runner-burst-config
+    globalMounts:
+      - path: /config
+        readOnly: true
+  data:
+    enabled: true
+    existingClaim: gitea-runner-burst
+    globalMounts:
+      - path: /data

--- a/docs/superpowers/plans/2026-07-02-gitea-runner-burst-pool.md
+++ b/docs/superpowers/plans/2026-07-02-gitea-runner-burst-pool.md
@@ -1,0 +1,327 @@
+# Gitea Runner Burst Pool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide a staged, isolated second Gitea runner pool so trusted workflows run concurrently without sharing runner or Docker state.
+
+**Architecture:** Keep the existing `gitea-runner` deployment and raise its capacity to two. Add an independent `gitea-runner-burst` app-template release with distinct config, secret target, VolSync data PVC, and Docker PVC; stage it at one concurrent job. Gitea dispatches matching Ubuntu-label workflows across the independent pools.
+
+**Tech Stack:** Kubernetes, Kustomize Helm charts, bjw-s app-template `5.0.1`, ArgoCD, ExternalSecrets, VolSync, Rook-Ceph, Gitea `act_runner` `0.6.1`.
+
+## Global Constraints
+
+- The baseline runner config map must set `runner.capacity: 2`.
+- The burst runner starts at `runner.capacity: 1`; increasing it is a later measured operational change.
+- The burst runner must use `gitea-runner-burst` for runner data and `gitea-runner-burst-docker` for Docker data, never either existing runner claim.
+- Both pools use the same pinned runner, Docker, and Ubuntu-label configuration as the current working runner.
+- The burst component must use ExternalSecrets and must not store token material in Git.
+- The burst ArgoCD application uses sync wave `20`, namespace `default`, Ceph block storage, `csi-ceph-blockpool`, a 2 GiB VolSync data claim, 8 GiB VolSync cache, and schedule `"40 */6 * * *"`.
+- Do not add queue-driven autoscaling, an HTTP endpoint, custom RBAC, controller code, or per-job ephemeral behavior.
+- Configuration-file behavior is verified with a Helm-enabled Kustomize rendering test; no unit-test framework is introduced.
+
+---
+
+### Task 1: Rendered-manifest regression test
+
+**Files:**
+- Create: `scripts/test-gitea-runner-pool-rendered-manifest.sh`
+
+**Interfaces:**
+- Consumes: `components/default/gitea-runner`, future `components/default/gitea-runner-burst`, and `clusters/talos/apps/20-applications.yaml`.
+- Produces: an executable, zero-exit rendered-manifest contract test.
+
+- [ ] **Step 1: Write the failing test**
+
+Create this executable Bash test. It follows `scripts/test-ntfy-rendered-manifest.sh`, renders Helm charts with Kustomize, and substitutes the ArgoCD plugin inputs locally.
+
+```bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly APPS_FILE="${ROOT_DIR}/clusters/talos/apps/20-applications.yaml"
+readonly BASELINE_COMPONENT="${ROOT_DIR}/components/default/gitea-runner"
+readonly BURST_COMPONENT="${ROOT_DIR}/components/default/gitea-runner-burst"
+readonly baseline_manifest="$(mktemp)"
+readonly burst_manifest="$(mktemp)"
+trap 'rm -f -- "${baseline_manifest}" "${burst_manifest}"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local message="$3"
+
+    [[ "${actual}" == "${expected}" ]] || fail "${message}: expected ${expected}, got ${actual:-<empty>}"
+}
+
+render_component() {
+    local app_name="$1"
+    local component="$2"
+    local output="$3"
+
+    export ARGOCD_APP_NAME="${app_name}"
+    export ARGOCD_ENV_STORAGE_CLASS="ceph-block"
+    export ARGOCD_ENV_VOLUME_SNAPSHOT_CLASS="csi-ceph-blockpool"
+    export ARGOCD_ENV_VOLSYNC_CAPACITY="2Gi"
+    export ARGOCD_ENV_VOLSYNC_CACHE_CAPACITY="8Gi"
+    export ARGOCD_ENV_VOLSYNC_SCHEDULE="40 */6 * * *"
+    export CLUSTER_DOMAIN="example.local"
+
+    kustomize build --enable-helm "${component}" | envsubst >"${output}"
+}
+
+config_capacity() {
+    local manifest="$1"
+    local config_map="$2"
+
+    yq ea -r "select(.kind == \"ConfigMap\" and .metadata.name == \"${config_map}\") | .data.\"config.yaml\" | from_yaml | .runner.capacity" "${manifest}"
+}
+
+resource_count() {
+    local manifest="$1"
+    local kind="$2"
+    local name="$3"
+
+    yq ea -r "[select(.kind == \"${kind}\" and .metadata.name == \"${name}\")] | length" "${manifest}"
+}
+
+claim_reference_count() {
+    local manifest="$1"
+    local claim="$2"
+
+    yq ea -r "[select(.kind == \"Deployment\" and .metadata.name == \"gitea-runner-burst\") | .spec.template.spec.volumes[]? | select(.persistentVolumeClaim.claimName == \"${claim}\")] | length" "${manifest}"
+}
+
+render_component "gitea-runner" "${BASELINE_COMPONENT}" "${baseline_manifest}"
+render_component "gitea-runner-burst" "${BURST_COMPONENT}" "${burst_manifest}"
+
+assert_equals "$(config_capacity "${baseline_manifest}" "gitea-runner-config")" "2" "baseline runner capacity"
+assert_equals "$(config_capacity "${burst_manifest}" "gitea-runner-burst-config")" "1" "burst runner capacity"
+assert_equals "$(resource_count "${burst_manifest}" "Deployment" "gitea-runner-burst")" "1" "burst deployment"
+assert_equals "$(resource_count "${burst_manifest}" "PersistentVolumeClaim" "gitea-runner-burst-docker")" "1" "burst Docker PVC"
+assert_equals "$(resource_count "${burst_manifest}" "PersistentVolumeClaim" "gitea-runner-burst")" "1" "burst runner-data PVC"
+assert_equals "$(claim_reference_count "${burst_manifest}" "gitea-runner-burst")" "1" "burst runner-data claim reference"
+assert_equals "$(claim_reference_count "${burst_manifest}" "gitea-runner-burst-docker")" "1" "burst Docker-data claim reference"
+assert_equals "$(claim_reference_count "${burst_manifest}" "gitea-runner")" "0" "baseline runner-data isolation"
+assert_equals "$(claim_reference_count "${burst_manifest}" "gitea-runner-docker")" "0" "baseline Docker-data isolation"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".annotations."argocd.argoproj.io/sync-wave"' "${APPS_FILE}")" "20" "burst ArgoCD sync wave"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".destination.namespace' "${APPS_FILE}")" "default" "burst ArgoCD namespace"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".source.path' "${APPS_FILE}")" "components/default/gitea-runner-burst" "burst ArgoCD path"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".source.plugin.env[] | select(.name == "STORAGE_CLASS") | .value' "${APPS_FILE}")" "ceph-block" "burst storage class"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".source.plugin.env[] | select(.name == "VOLUME_SNAPSHOT_CLASS") | .value' "${APPS_FILE}")" "csi-ceph-blockpool" "burst snapshot class"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".source.plugin.env[] | select(.name == "VOLSYNC_CAPACITY") | .value' "${APPS_FILE}")" "2Gi" "burst VolSync capacity"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".source.plugin.env[] | select(.name == "VOLSYNC_CACHE_CAPACITY") | .value' "${APPS_FILE}")" "8Gi" "burst VolSync cache capacity"
+assert_equals "$(yq e -r '.applications."gitea-runner-burst".source.plugin.env[] | select(.name == "VOLSYNC_SCHEDULE") | .value' "${APPS_FILE}")" "40 */6 * * *" "burst VolSync schedule"
+
+printf 'PASS: rendered Gitea runner pools have independent claims, staged capacity, and ArgoCD registration\n'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bash scripts/test-gitea-runner-pool-rendered-manifest.sh
+```
+
+Expected: failure because `components/default/gitea-runner-burst` does not exist yet.
+
+- [ ] **Step 3: Keep the failing test unchanged while implementing Tasks 2 and 3**
+
+The test is the behavior contract. Do not weaken it to accommodate an incorrect storage relationship.
+
+### Task 2: Baseline capacity and isolated burst component
+
+**Files:**
+- Modify: `components/default/gitea-runner/configmap.yaml:11-17`
+- Create: `components/default/gitea-runner-burst/configmap.yaml`
+- Create: `components/default/gitea-runner-burst/external-secret.yaml`
+- Create: `components/default/gitea-runner-burst/kustomization.yaml`
+- Create: `components/default/gitea-runner-burst/pvc-docker.yaml`
+- Create: `components/default/gitea-runner-burst/values.yaml`
+
+**Interfaces:**
+- Consumes: the existing `gitea-runner` component layout, Gitea `RUNNER_TOKEN` field, and the VolSync component's `${ARGOCD_APP_NAME}` data-claim convention.
+- Produces: two independently stateful Gitea runner deployments that expose matching Ubuntu labels.
+
+- [ ] **Step 1: Increase baseline concurrency**
+
+Change the existing ConfigMap to:
+
+```yaml
+runner:
+  file: /data/.runner
+  capacity: 2
+```
+
+Do not change labels, timeouts, cache, or container configuration.
+
+- [ ] **Step 2: Create the burst ConfigMap**
+
+Create `gitea-runner-burst-config` using the current runner ConfigMap as the exact behavioral template, with only these identity changes:
+
+```yaml
+metadata:
+  name: gitea-runner-burst-config
+runner:
+  file: /data/.runner
+  capacity: 1
+```
+
+Keep the same timeout, fetch behavior, Docker host, labels, cache settings, and volume policy as the baseline ConfigMap.
+
+- [ ] **Step 3: Create the burst ExternalSecret**
+
+Create an ExternalSecret named `gitea-runner-burst` targeting `gitea-runner-burst-secret`, sourced from the existing `gitea` 1Password item, with only:
+
+```yaml
+data:
+  GITEA_RUNNER_REGISTRATION_TOKEN: "{{ .RUNNER_TOKEN }}"
+```
+
+- [ ] **Step 4: Create isolated Docker storage**
+
+Create a `ReadWriteOnce`, `ceph-block`, 100 GiB PVC named `gitea-runner-burst-docker`.
+
+- [ ] **Step 5: Create the burst Kustomization**
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../volsync-system/volsync-replication
+resources:
+  - ./external-secret.yaml
+  - ./configmap.yaml
+  - ./pvc-docker.yaml
+helmCharts:
+  - name: app-template
+    releaseName: gitea-runner-burst
+    namespace: default
+    repo: oci://ghcr.io/bjw-s-labs/helm
+    version: "5.0.1"
+    valuesFile: values.yaml
+```
+
+- [ ] **Step 6: Create burst Helm values**
+
+Copy the existing runner's controller, runner image digest, Docker image, Docker readiness command, security context, resource requests/limits, and persistence layout. Change only identity and state references:
+
+```yaml
+controllers:
+  app:
+    replicas: 1
+    strategy: Recreate
+    containers:
+      runner:
+        envFrom:
+          - secretRef:
+              name: gitea-runner-burst-secret
+persistence:
+  docker-data:
+    existingClaim: gitea-runner-burst-docker
+  config:
+    name: gitea-runner-burst-config
+  data:
+    existingClaim: gitea-runner-burst
+```
+
+No value may reference `gitea-runner-docker`, `gitea-runner-secret`, or `gitea-runner-config`.
+
+- [ ] **Step 7: Run direct Helm-enabled manifest renders**
+
+Run:
+
+```bash
+export ARGOCD_APP_NAME=gitea-runner
+export ARGOCD_ENV_STORAGE_CLASS=ceph-block
+export ARGOCD_ENV_VOLUME_SNAPSHOT_CLASS=csi-ceph-blockpool
+export ARGOCD_ENV_VOLSYNC_CAPACITY=2Gi
+export ARGOCD_ENV_VOLSYNC_CACHE_CAPACITY=8Gi
+export ARGOCD_ENV_VOLSYNC_SCHEDULE='40 */6 * * *'
+kustomize build --enable-helm components/default/gitea-runner | envsubst >/tmp/gitea-runner.yaml
+
+export ARGOCD_APP_NAME=gitea-runner-burst
+kustomize build --enable-helm components/default/gitea-runner-burst | envsubst >/tmp/gitea-runner-burst.yaml
+```
+
+Expected: both commands exit zero; the second render includes `Deployment/gitea-runner-burst`, `PersistentVolumeClaim/gitea-runner-burst`, and `PersistentVolumeClaim/gitea-runner-burst-docker`.
+
+### Task 3: ArgoCD registration, validation, and documentation
+
+**Files:**
+- Modify: `clusters/talos/apps/20-applications.yaml:142-161`
+- Modify: `docs/superpowers/specs/2026-07-02-gitea-runner-burst-pool-design.md`
+
+**Interfaces:**
+- Consumes: the `components/default/gitea-runner-burst` component and the app-of-apps plugin environment contract.
+- Produces: ArgoCD reconciliation of the burst runner and documented staged operational capacity.
+
+- [ ] **Step 1: Register the burst application directly after `gitea-runner`**
+
+```yaml
+gitea-runner-burst:
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+  destination:
+    namespace: default
+  source:
+    path: components/default/gitea-runner-burst
+    plugin:
+      env:
+        - name: STORAGE_CLASS
+          value: ceph-block
+        - name: VOLUME_SNAPSHOT_CLASS
+          value: csi-ceph-blockpool
+        - name: VOLSYNC_CAPACITY
+          value: 2Gi
+        - name: VOLSYNC_CACHE_CAPACITY
+          value: 8Gi
+        - name: VOLSYNC_SCHEDULE
+          value: "40 */6 * * *"
+```
+
+- [ ] **Step 2: Record validation and rollout evidence in the design document**
+
+Append `## Validation` with these exact commands:
+
+```bash
+bash scripts/test-gitea-runner-pool-rendered-manifest.sh
+bash scripts/kubeconform.sh
+pre-commit run --all-files
+```
+
+State that the first live rollout permits three concurrent jobs and requires observed resource headroom before the burst capacity changes from one to two.
+
+- [ ] **Step 3: Run focused and repository validation**
+
+Run:
+
+```bash
+bash scripts/test-gitea-runner-pool-rendered-manifest.sh
+bash scripts/kubeconform.sh
+pre-commit run --all-files
+```
+
+Expected: all commands exit zero. The focused test validates Helm rendering, capacity, storage isolation, and Argo registration; kubeconform validates repository manifests; pre-commit validates YAML and secret policy.
+
+- [ ] **Step 4: Commit the reviewed change**
+
+```bash
+git add components/default/gitea-runner/configmap.yaml components/default/gitea-runner-burst clusters/talos/apps/20-applications.yaml scripts/test-gitea-runner-pool-rendered-manifest.sh docs/superpowers/specs/2026-07-02-gitea-runner-burst-pool-design.md docs/superpowers/plans/2026-07-02-gitea-runner-burst-pool.md
+git commit -m "feat: add isolated Gitea runner burst pool"
+```
+
+Expected: one focused commit, ready for independent review.
+
+## Plan self-review
+
+- Spec coverage: Task 1 makes capacity, storage, and registration invariants executable. Task 2 creates independent runner pools and directly renders the Helm-backed manifests. Task 3 registers the workload, documents staged operation, and runs all validation.
+- Placeholder scan: no TBD, TODO, or deferred implementation instructions remain.
+- Consistency: component name, release name, VolSync claim, Docker claim, config map, ExternalSecret target, and ArgoCD app name are all `gitea-runner-burst` with the resource-specific suffix only where required.

--- a/docs/superpowers/specs/2026-07-02-gitea-runner-burst-pool-design.md
+++ b/docs/superpowers/specs/2026-07-02-gitea-runner-burst-pool-design.md
@@ -1,0 +1,66 @@
+# Gitea Runner Burst Pool Design
+
+## Goal
+
+Allow up to four trusted Gitea Actions jobs to run concurrently without sharing runner registration state or Docker daemon state between runner deployments.
+
+## Scope
+
+- Raise the existing `gitea-runner` capacity from one to two jobs.
+- Add a second long-lived `gitea-runner-burst` deployment with capacity one for the initial rollout.
+- Give the burst deployment its own VolSync-managed runner-data PVC and its own Docker-data PVC.
+- Register the new component as an ArgoCD application at sync wave 20.
+- Add a rendered-manifest regression test covering both pools.
+
+## Non-goals
+
+- Queue-driven autoscaling.
+- Ephemeral per-job runners.
+- Webhook receivers, custom controllers, KEDA, or new RBAC.
+- Public ingress, new external secrets, or new Gitea registration tokens.
+- Changes to Gitea Actions workflow files.
+
+## Architecture
+
+`gitea-runner` and `gitea-runner-burst` are independent, long-lived Gitea `act_runner` deployments. Both use the existing Gitea registration token and advertise the existing Ubuntu labels, allowing Gitea to dispatch matching work to either free capacity slot.
+
+Each deployment owns two storage domains:
+
+| Deployment | Runner data | Docker data |
+| --- | --- | --- |
+| `gitea-runner` | `gitea-runner` | `gitea-runner-docker` |
+| `gitea-runner-burst` | `gitea-runner-burst` | `gitea-runner-burst-docker` |
+
+The runner-data PVC is created by the existing VolSync component from `${ARGOCD_APP_NAME}`. The Docker-data PVC is explicit because Docker state is not replicated by VolSync.
+
+## Capacity rollout
+
+The existing runner immediately moves to `runner.capacity: 2`. The burst deployment begins at `runner.capacity: 1`; the staged deployment therefore provides three concurrent jobs. After observed validation with representative builds, change the burst capacity to two for a four-job steady-state maximum.
+
+This staging is intentionally different from the final four-slot target. Two independent privileged Docker daemons with concurrent workloads can increase memory, CPU, image-layer, and node-pressure demand. The first production rollout must establish a safe measured baseline.
+
+## Security and isolation
+
+The existing Docker-in-Docker daemon is privileged. This design preserves its current trusted-project model and does not make it appropriate for untrusted pull requests. It improves fault isolation by ensuring the two daemons never mount the same `/var/lib/docker` claim and the runners never share a `.runner` registration file.
+
+No new Kubernetes permissions, endpoint, or plaintext secret are introduced. The burst component receives its own ExternalSecret target backed by the existing concealed `RUNNER_TOKEN` in the `gitea` 1Password item. Gitea supports a registration token registering multiple runners until it is reset.
+
+## Verification
+
+A focused rendered-manifest test must prove:
+
+1. The baseline config map has capacity two.
+2. The burst config map has capacity one for the staged rollout.
+3. The burst deployment mounts `gitea-runner-burst` and `gitea-runner-burst-docker` only.
+4. The burst component renders a Deployment, its Docker PVC, and its VolSync runner-data PVC.
+5. `clusters/talos/apps/20-applications.yaml` registers the burst application with the existing Ceph/VolSync settings at sync wave 20.
+
+Run the focused test, repository kubeconform validation, and pre-commit hooks before opening the merge request.
+
+The initial staged pool capacity is three concurrent jobs.
+
+```bash
+bash scripts/test-gitea-runner-pool-rendered-manifest.sh
+bash scripts/kubeconform.sh
+pre-commit run --all-files
+```

--- a/scripts/test-gitea-runner-pool-rendered-manifest.sh
+++ b/scripts/test-gitea-runner-pool-rendered-manifest.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Contract test for the staged Gitea runner pool: a baseline runner
+# (capacity 2) plus a burst runner (capacity 1) that shares no persistent
+# state with the baseline. Both components are rendered as ArgoCD would render
+# them — `kustomize build --enable-helm` piped through `envsubst` restricted to
+# an explicit allowlist of the seven plugin variables ArgoCD injects — so the
+# assertions run against the real rendered Helm output, not the source YAML.
+# The rendered manifests (which contain ExternalSecret definitions) are never
+# printed; assertions inspect resource names, counts, and scalar fields only.
+
+readonly ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly BASELINE_COMPONENT="${ROOT_DIR}/components/default/gitea-runner"
+readonly BURST_COMPONENT="${ROOT_DIR}/components/default/gitea-runner-burst"
+readonly APPLICATIONS="${ROOT_DIR}/clusters/talos/apps/20-applications.yaml"
+
+readonly BASELINE_APP="gitea-runner"
+readonly BURST_APP="gitea-runner-burst"
+
+umask 077
+readonly baseline_manifest="$(mktemp)"
+readonly burst_manifest="$(mktemp)"
+trap 'rm -f -- "${baseline_manifest}" "${burst_manifest}"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+# Render a component the way ArgoCD does: kustomize build --enable-helm, then
+# envsubst with the plugin environment. VOLSYNC_SCHEDULE is quoted because it
+# contains spaces and glob characters.
+render() {
+    local component="$1" app_name="$2" out="$3"
+
+    [[ -d "${component}" ]] || fail "component directory is missing: ${component}"
+
+    # Restrict envsubst to exactly the seven plugin variables ArgoCD injects, so
+    # any other `$word` inside rendered manifests (shell snippets, Go templates)
+    # is left untouched. The schedule value carries spaces/glob chars; it is
+    # exported, never word-split into the allowlist.
+    local -r allowlist='${ARGOCD_APP_NAME} ${ARGOCD_ENV_STORAGE_CLASS} ${ARGOCD_ENV_VOLUME_SNAPSHOT_CLASS} ${ARGOCD_ENV_VOLSYNC_CAPACITY} ${ARGOCD_ENV_VOLSYNC_CACHE_CAPACITY} ${ARGOCD_ENV_VOLSYNC_SCHEDULE} ${CLUSTER_DOMAIN}'
+
+    ARGOCD_APP_NAME="${app_name}" \
+    ARGOCD_ENV_STORAGE_CLASS="ceph-block" \
+    ARGOCD_ENV_VOLUME_SNAPSHOT_CLASS="csi-ceph-blockpool" \
+    ARGOCD_ENV_VOLSYNC_CAPACITY="2Gi" \
+    ARGOCD_ENV_VOLSYNC_CACHE_CAPACITY="8Gi" \
+    ARGOCD_ENV_VOLSYNC_SCHEDULE="40 */6 * * *" \
+    CLUSTER_DOMAIN="example.local" \
+        bash -c '
+            set -Eeuo pipefail
+            kustomize build --enable-helm "$1" | envsubst "$2"
+        ' _ "${component}" "${allowlist}" >"${out}" \
+        || fail "kustomize/envsubst render failed for ${app_name} (${component})"
+}
+
+deployment_replicas() {
+    local manifest="$1" name="$2"
+
+    yq ea -r "[select(.kind == \"Deployment\" and .metadata.name == \"${name}\") | .spec.replicas] | .[0] // \"none\"" "${manifest}"
+}
+
+# runner.capacity from the embedded act_runner config.yaml inside a rendered
+# ConfigMap. This is the number of concurrent jobs a single runner process
+# accepts — the pool's real capacity knob, independent of Deployment replicas.
+runner_capacity() {
+    local manifest="$1" name="$2"
+
+    yq ea -r "[select(.kind == \"ConfigMap\" and .metadata.name == \"${name}\") | .data[\"config.yaml\"] | from_yaml | .runner.capacity] | .[0] // \"none\"" "${manifest}"
+}
+
+resource_count() {
+    local manifest="$1" kind="$2" name="$3"
+
+    yq ea -r "[select(.kind == \"${kind}\" and .metadata.name == \"${name}\")] | length" "${manifest}"
+}
+
+# Sorted persistent claims mounted by a Deployment's pod template. Sorting lets
+# the caller assert an exact claim set without exposing rendered manifests.
+deployment_claims() {
+    local manifest="$1" name="$2"
+
+    yq ea -r "[select(.kind == \"Deployment\" and .metadata.name == \"${name}\") | .spec.template.spec.volumes[]? | select(.persistentVolumeClaim) | .persistentVolumeClaim.claimName] | sort | .[]" "${manifest}"
+}
+
+# Sorted ConfigMaps mounted through a Deployment's pod volumes.
+deployment_config_maps() {
+    local manifest="$1" name="$2"
+
+    yq ea -r "[select(.kind == \"Deployment\" and .metadata.name == \"${name}\") | .spec.template.spec.volumes[]? | select(.configMap) | .configMap.name] | sort | .[]" "${manifest}"
+}
+
+# Secret names referenced by the named runner container's envFrom entries.
+# Only names are returned; secret values are never inspected or printed.
+runner_envfrom_secrets() {
+    local manifest="$1" deployment="$2" container="$3"
+
+    yq ea -r "[select(.kind == \"Deployment\" and .metadata.name == \"${deployment}\") | .spec.template.spec.containers[]? | select(.name == \"${container}\") | .envFrom[]? | select(.secretRef) | .secretRef.name] | sort | .[]" "${manifest}"
+}
+
+external_secret_target() {
+    local manifest="$1" name="$2"
+
+    yq ea -r "[select(.kind == \"ExternalSecret\" and .metadata.name == \"${name}\") | .spec.target.name] | .[0] // \"none\"" "${manifest}"
+}
+
+app_field() {
+    local expr="$1"
+
+    yq ea -r "select(.applications) | .applications.\"${BURST_APP}\" | ${expr}" "${APPLICATIONS}"
+}
+
+plugin_env_value() {
+    local var="$1"
+
+    app_field ".source.plugin.env[]? | select(.name == \"${var}\") | .value"
+}
+
+render "${BASELINE_COMPONENT}" "${BASELINE_APP}" "${baseline_manifest}"
+
+# --- Burst component exists and renders -------------------------------------
+# Checked first: until the burst component is authored this is the contract's
+# primary gap, and it should be the failure the test reports.
+[[ -d "${BURST_COMPONENT}" ]] \
+    || fail "burst component is missing: expected ${BURST_COMPONENT}"
+
+render "${BURST_COMPONENT}" "${BURST_APP}" "${burst_manifest}"
+
+# --- Baseline capacity ------------------------------------------------------
+# Capacity is act_runner's runner.capacity (concurrent jobs per runner), read
+# from the rendered ConfigMap. Each pool runs a single pod, so both Deployments
+# keep spec.replicas == 1; scaling concurrency is done via runner.capacity.
+[[ "$(resource_count "${baseline_manifest}" Deployment "${BASELINE_APP}")" == "1" ]] \
+    || fail "rendered baseline Deployment ${BASELINE_APP} is missing or ambiguous"
+[[ "$(resource_count "${baseline_manifest}" ConfigMap "${BASELINE_APP}-config")" == "1" ]] \
+    || fail "rendered baseline ConfigMap ${BASELINE_APP}-config is missing or ambiguous"
+[[ "$(runner_capacity "${baseline_manifest}" "${BASELINE_APP}-config")" == "2" ]] \
+    || fail "rendered baseline ConfigMap ${BASELINE_APP}-config runner.capacity must be 2"
+[[ "$(deployment_replicas "${baseline_manifest}" "${BASELINE_APP}")" == "1" ]] \
+    || fail "rendered baseline ${BASELINE_APP} Deployment must run a single pod (spec.replicas == 1)"
+
+# --- Burst capacity ---------------------------------------------------------
+[[ "$(resource_count "${burst_manifest}" ConfigMap "${BURST_APP}-config")" == "1" ]] \
+    || fail "rendered burst ConfigMap ${BURST_APP}-config is missing or ambiguous"
+[[ "$(runner_capacity "${burst_manifest}" "${BURST_APP}-config")" == "1" ]] \
+    || fail "rendered burst ConfigMap ${BURST_APP}-config runner.capacity must be 1"
+[[ "$(deployment_replicas "${burst_manifest}" "${BURST_APP}")" == "1" ]] \
+    || fail "rendered burst ${BURST_APP} Deployment must run a single pod (spec.replicas == 1)"
+
+# --- Burst resources and wiring ---------------------------------------------
+[[ "$(resource_count "${burst_manifest}" Deployment "${BURST_APP}")" == "1" ]] \
+    || fail "rendered burst Deployment ${BURST_APP} is missing or ambiguous"
+[[ "$(resource_count "${burst_manifest}" PersistentVolumeClaim "${BURST_APP}")" == "1" ]] \
+    || fail "rendered burst data PVC ${BURST_APP} is missing or ambiguous"
+[[ "$(resource_count "${burst_manifest}" PersistentVolumeClaim "${BURST_APP}-docker")" == "1" ]] \
+    || fail "rendered burst docker PVC ${BURST_APP}-docker is missing or ambiguous"
+[[ "$(resource_count "${burst_manifest}" ExternalSecret "${BURST_APP}")" == "1" ]] \
+    || fail "rendered burst ExternalSecret ${BURST_APP} is missing or ambiguous"
+[[ "$(external_secret_target "${burst_manifest}" "${BURST_APP}")" == "${BURST_APP}-secret" ]] \
+    || fail "rendered burst ExternalSecret ${BURST_APP} must target ${BURST_APP}-secret"
+
+# The complete persistent-claim set must be its two dedicated claims: this
+# rejects missing, baseline, or any unexpected shared claim.
+burst_claims="$(deployment_claims "${burst_manifest}" "${BURST_APP}")"
+[[ "${burst_claims}" == "${BURST_APP}"$'\n'"${BURST_APP}-docker" ]] \
+    || fail "burst ${BURST_APP} Deployment must mount exactly ${BURST_APP} and ${BURST_APP}-docker"
+[[ "$(deployment_config_maps "${burst_manifest}" "${BURST_APP}")" == "${BURST_APP}-config" ]] \
+    || fail "burst ${BURST_APP} Deployment must mount exactly ConfigMap ${BURST_APP}-config"
+[[ "$(runner_envfrom_secrets "${burst_manifest}" "${BURST_APP}" runner)" == "${BURST_APP}-secret" ]] \
+    || fail "burst ${BURST_APP} runner container envFrom must reference exactly ${BURST_APP}-secret"
+
+# --- ArgoCD registration ----------------------------------------------------
+[[ "$(app_field 'has("source")')" == "true" ]] \
+    || fail "ArgoCD application ${BURST_APP} is not registered in ${APPLICATIONS}"
+[[ "$(app_field '.source.path')" == "components/default/${BURST_APP}" ]] \
+    || fail "ArgoCD ${BURST_APP} source.path must be components/default/${BURST_APP}"
+[[ "$(app_field '.destination.namespace')" == "default" ]] \
+    || fail "ArgoCD ${BURST_APP} destination.namespace must be default"
+[[ "$(app_field '.annotations."argocd.argoproj.io/sync-wave"')" == "20" ]] \
+    || fail "ArgoCD ${BURST_APP} sync-wave must be 20"
+
+[[ "$(plugin_env_value STORAGE_CLASS)" == "ceph-block" ]] \
+    || fail "ArgoCD ${BURST_APP} plugin STORAGE_CLASS must be ceph-block"
+[[ "$(plugin_env_value VOLUME_SNAPSHOT_CLASS)" == "csi-ceph-blockpool" ]] \
+    || fail "ArgoCD ${BURST_APP} plugin VOLUME_SNAPSHOT_CLASS must be csi-ceph-blockpool"
+[[ "$(plugin_env_value VOLSYNC_CAPACITY)" == "2Gi" ]] \
+    || fail "ArgoCD ${BURST_APP} plugin VOLSYNC_CAPACITY must be 2Gi"
+[[ "$(plugin_env_value VOLSYNC_CACHE_CAPACITY)" == "8Gi" ]] \
+    || fail "ArgoCD ${BURST_APP} plugin VOLSYNC_CACHE_CAPACITY must be 8Gi"
+[[ "$(plugin_env_value VOLSYNC_SCHEDULE)" == "40 */6 * * *" ]] \
+    || fail "ArgoCD ${BURST_APP} plugin VOLSYNC_SCHEDULE must be '40 */6 * * *'"
+
+printf 'PASS: gitea runner pool baseline capacity, burst capacity, burst workload wiring, and ArgoCD burst registration are consistent\n'


### PR DESCRIPTION
## Summary
- raise the baseline Gitea runner to two concurrent jobs
- add an isolated one-job burst runner with separate runner and Docker claims
- register the burst runner in ArgoCD and add a rendered-manifest contract test

## Verification
- `bash scripts/test-gitea-runner-pool-rendered-manifest.sh`
- `bash scripts/kubeconform.sh`
- `pre-commit run --files <changed files>`

`pre-commit run --all-files` remains blocked by pre-existing yamllint errors in unrelated manifests; this change does not modify them.

## Rollout
The initial steady-state capacity is three concurrent jobs: baseline capacity 2 plus burst capacity 1. Increase the burst runner to capacity 2 only after observing adequate cluster resource headroom.