### PR TITLE
feat: increase agent-memory resource requests and limits

### DIFF
--- a/components/ai/agentmemory/values.yaml
+++ b/components/ai/agentmemory/values.yaml
@@ -83,10 +83,11 @@ controllers:
               timeoutSeconds: 5
         resources:
           requests:
-            cpu: 100m
-            memory: 1Gi
+            cpu: 200m
+            memory: 2Gi
           limits:
-            memory: 3Gi
+            cpu: 500m
+            memory: 6Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary

Increase resource requests and limits for the `agentmemory` deployment to provide production-grade resource allocations.

## Changes

Updated `components/ai/agentmemory/values.yaml`:

| Resource | Before | After |
|----------|--------|-------|
| CPU requests | `100m` | `200m` |
| Memory requests | `1Gi` | `2Gi` |
| CPU limits | _(none)_ | `500m` |
| Memory limits | `3Gi` | `6Gi` |

## Rationale

- Memory requests and limits are approximately doubled to improve stability under load
- CPU requests are doubled proportionally
- CPU limits are added (`500m`) to prevent unbounded CPU consumption
- These values provide a reasonable production-grade baseline for the agent-memory service