### PR TITLE
fix(forge): allow Sigstore TUF verification during setup

### DIFF
--- a/components/ai/forge/values.yaml
+++ b/components/ai/forge/values.yaml
@@ -38,7 +38,8 @@ controllers:
           FORGE_TOOL_ALLOWLIST: node,python,go,kubectl,kustomize,kubeconform,helm,uv
           # api.github.com: mise's aqua backend resolves release metadata there;
           # release-assets.githubusercontent.com serves the actual downloads.
-          FORGE_TOOL_MIRROR_HOSTS: github.com,api.github.com,objects.githubusercontent.com,release-assets.githubusercontent.com,nodejs.org,dl.k8s.io
+          # Sigstore TUF root metadata enables mise artifact signature verification.
+          FORGE_TOOL_MIRROR_HOSTS: github.com,api.github.com,objects.githubusercontent.com,release-assets.githubusercontent.com,nodejs.org,dl.k8s.io,tuf-repo-cdn.sigstore.dev
         envFrom: *envFrom
         resources:
           requests:


### PR DESCRIPTION
## Why

`mise install uv` validates the locked uv artifact through Sigstore TUF metadata. The trusted setup step was blocked because `tuf-repo-cdn.sigstore.dev` was absent from the existing mirror-host allowlist.

## Scope

Adds exactly `tuf-repo-cdn.sigstore.dev` to `FORGE_TOOL_MIRROR_HOSTS` and documents the verification purpose. The Forge runner applies this host only to `/usr/local/bin/mise` while environment setup runs; normal agent egress is unchanged.

## Validation

`kustomize build --enable-helm --load-restrictor=LoadRestrictionsNone --enable-alpha-plugins components/ai/forge | envsubst | kubeconform -strict -ignore-missing-schemas -summary`

Result: 6 resources parsed, 4 valid, 0 invalid, 0 errors, 2 skipped.