### PR TITLE
feat: export Hermes traces through NeMo Relay

### DIFF
--- a/components/ai/hermes-agent/configmap.yaml
+++ b/components/ai/hermes-agent/configmap.yaml
@@ -217,6 +217,7 @@ data:
         - forge
         - web/ddgs
         - security-guidance
+        - observability/nemo_relay
     platforms:
       telegram:
         extra:
@@ -313,3 +314,24 @@ data:
         - ivan_paperless
         - ivan_synology
         - ivan_travel
+  nemo-relay-plugins.toml: |-
+    version = 1
+
+    [[components]]
+    kind = "observability"
+    enabled = true
+
+    [components.config]
+    version = 1
+
+    [components.config.openinference]
+    enabled = true
+    transport = "http_binary"
+    endpoint = "http://alloy.observability.svc.cluster.local:4318/v1/traces"
+    service_name = "hermes-agent"
+    service_namespace = "ai"
+    instrumentation_scope = "hermes-nemo-relay"
+    timeout_millis = 3000
+
+    [components.config.openinference.resource_attributes]
+    "deployment.environment" = "talos"

--- a/components/ai/hermes-agent/values.yaml
+++ b/components/ai/hermes-agent/values.yaml
@@ -13,7 +13,7 @@ controllers:
       hermes-bootstrap:
         image:
           repository: gitea.a113.casa/vpogu/agent-platform-hermes-agent
-          tag: 20260702133755-ffd50fc-oci
+          tag: 20260702184336-85d48a6-oci
         command: ["python", "/etc/hermes-bootstrap/bootstrap.py"]
         env:
           PYTHONUNBUFFERED: "1"
@@ -36,13 +36,13 @@ controllers:
           capabilities: {drop: ["ALL"]}
       seed-config:
         image:
-          tag: 20260702133755-ffd50fc-oci
+          tag: 20260702184336-85d48a6-oci
           repository: gitea.a113.casa/vpogu/agent-platform-hermes-agent
     containers:
       app:
         image:
           repository: gitea.a113.casa/vpogu/agent-platform-hermes-agent
-          tag: 20260702133755-ffd50fc-oci
+          tag: 20260702184336-85d48a6-oci
         args:
         - gateway
         - run
@@ -67,6 +67,7 @@ controllers:
           API_SERVER_HOST: "127.0.0.1"
           API_SERVER_PORT: "8642"
           AGENTMEMORY_URL: http://agentmemory.ai.svc.cluster.local:3111
+          HERMES_NEMO_RELAY_PLUGINS_TOML: /opt/data/nemo-relay-plugins.toml
           TZ: America/New_York
           HEADROOM_PROXY_URL: http://headroom.ai.svc.cluster.local:8787
         envFrom:
@@ -105,6 +106,10 @@ persistence:
         hermes-bootstrap:
         - path: /opt/bootstrap/config.yaml
           subPath: config.yaml
+          readOnly: true
+        app:
+        - path: /opt/data/nemo-relay-plugins.toml
+          subPath: nemo-relay-plugins.toml
           readOnly: true
   bootstrap:
     type: configMap

--- a/docs/superpowers/plans/2026-07-02-hermes-nemo-relay-observability.md
+++ b/docs/superpowers/plans/2026-07-02-hermes-nemo-relay-observability.md
@@ -1,0 +1,175 @@
+# Hermes NeMo Relay Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `subagent-driven-development` (recommended) or `executing-plans`. Execute task-by-task, retaining the verification evidence listed in each task.
+
+**Goal:** Export Hermes Agent OpenInference traces through Alloy to Tempo and Grafana using the published NeMo Relay-enabled image.
+
+**Architecture:** Hermes enables its bundled `observability/nemo_relay` plugin from the existing persistent-home configuration. A ConfigMap-mounted NeMo Relay `plugins.toml` enables only the OpenInference exporter and sends OTLP HTTP to Alloy's in-cluster receiver. Alloy keeps ownership of trace forwarding to Tempo; no Relay gateway or new network resource is created.
+
+**Tech Stack:** Kubernetes, Kustomize, bjw-s app-template 5.0.1, Hermes Agent, NeMo Relay 0.3.0, OpenInference OTLP HTTP, Grafana Alloy, Tempo, Bash, yq.
+
+## Global Constraints
+
+- Use image tag `20260702184336-85d48a6-oci` from verified `agent-platform-custom` commit `85d48a6` for every Hermes container.
+- Enable only `observability/nemo_relay`; do not change Hermes model provider URLs or add a NeMo Relay proxy.
+- Export only OpenInference OTLP HTTP to `http://alloy.observability.svc.cluster.local:4318/v1/traces`.
+- Do not enable ATOF/ATIF local disk exporters, create network objects, or add secrets.
+- Preserve the existing Hermes PVC, resource settings, security contexts, and ingress.
+
+---
+
+### Task 1: Add a failing rendered-manifest contract
+
+**Files:**
+- Create: `scripts/test-hermes-nemo-relay-rendered-manifest.sh`
+
+**Interfaces:**
+- Consumes: `components/ai/hermes-agent` Kustomization rendered with `kustomize build --enable-helm`.
+- Produces: an executable zero-exit contract test that asserts the Hermes Deployment and `hermes-agent-config` ConfigMap integration contract.
+
+- [ ] **Step 1: Write the failing test**
+
+Create an executable Bash test matching `scripts/test-ntfy-rendered-manifest.sh` conventions. Render `components/ai/hermes-agent` into a `mktemp` manifest and use `yq ea` assertions to require:
+
+```bash
+[[ "$(yq ea -r '
+  select(.kind == "ConfigMap" and .metadata.name == "hermes-agent-config")
+  | .data["nemo-relay-plugins.toml"]
+  | contains("kind = \"observability\"")
+    and contains("[components.config.openinference]")
+    and contains("endpoint = \"http://alloy.observability.svc.cluster.local:4318/v1/traces\"")
+' "${manifest}")" == "true" ]] || fail "NeMo Relay OpenInference ConfigMap entry is missing or invalid"
+```
+
+Also assert exactly one rendered Hermes application container uses `gitea.a113.casa/vpogu/agent-platform-hermes-agent:20260702184336-85d48a6-oci`, has `HERMES_NEMO_RELAY_PLUGINS_TOML=/opt/data/nemo-relay-plugins.toml`, and mounts ConfigMap key `nemo-relay-plugins.toml` read-only at that same path.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+bash scripts/test-hermes-nemo-relay-rendered-manifest.sh
+```
+
+Expected: failure because the current ConfigMap lacks `nemo-relay-plugins.toml` and the Deployment has no environment variable or mount.
+
+- [ ] **Step 3: Commit test-only red state only if collaboration requires it**
+
+Do not commit an intentionally failing test to the integration branch. Continue directly to Task 2 in the same working tree.
+
+### Task 2: Enable NeMo Relay OpenInference export
+
+**Files:**
+- Modify: `components/ai/hermes-agent/configmap.yaml`
+- Modify: `components/ai/hermes-agent/values.yaml`
+
+**Interfaces:**
+- Consumes: the `nemo-relay==0.3.0` runtime and `observability/nemo_relay` plugin verified in image commit `85d48a6`.
+- Produces: an enabled Hermes plugin, a mounted NeMo Relay plugin document, and a Deployment that exports OpenInference OTLP directly to Alloy.
+
+- [ ] **Step 1: Enable the Hermes plugin**
+
+Add the plugin to the existing configuration list:
+
+```yaml
+plugins:
+  enabled:
+    - ivan-personal
+    - disk-cleanup
+    - rtk-rewrite
+    - forge
+    - web/ddgs
+    - security-guidance
+    - observability/nemo_relay
+```
+
+- [ ] **Step 2: Add the NeMo Relay plugin document**
+
+Add `nemo-relay-plugins.toml` as a second key in `hermes-agent-config`:
+
+```toml
+version = 1
+
+[[components]]
+kind = "observability"
+enabled = true
+
+[components.config]
+version = 1
+
+[components.config.openinference]
+enabled = true
+transport = "http_binary"
+endpoint = "http://alloy.observability.svc.cluster.local:4318/v1/traces"
+service_name = "hermes-agent"
+service_namespace = "ai"
+instrumentation_scope = "hermes-nemo-relay"
+timeout_millis = 3000
+
+[components.config.openinference.resource_attributes]
+"deployment.environment" = "talos"
+```
+
+- [ ] **Step 3: Wire the Deployment to the document and published image**
+
+Replace all three Hermes image tags with `20260702184336-85d48a6-oci`. Under the app container environment, add:
+
+```yaml
+HERMES_NEMO_RELAY_PLUGINS_TOML: /opt/data/nemo-relay-plugins.toml
+```
+
+Under the existing `config.advancedMounts.app.app` list, add:
+
+```yaml
+- path: /opt/data/nemo-relay-plugins.toml
+  subPath: nemo-relay-plugins.toml
+  readOnly: true
+```
+
+This uses the existing ConfigMap reloader and its `config` volume; no new workload object is needed.
+
+### Task 3: Verify rendered integration
+
+**Files:**
+- Test: `scripts/test-hermes-nemo-relay-rendered-manifest.sh`
+
+**Interfaces:**
+- Consumes: Task 2 manifest configuration.
+- Produces: verified rendered ConfigMap and Deployment contract.
+
+- [ ] **Step 1: Run the rendered-manifest contract**
+
+Run:
+
+```bash
+bash scripts/test-hermes-nemo-relay-rendered-manifest.sh
+```
+
+Expected: `PASS` message naming the published image tag, enabled plugin, OTLP endpoint, environment variable, and ConfigMap mount.
+
+- [ ] **Step 2: Validate script syntax and Kustomize/Helm rendering**
+
+Run:
+
+```bash
+bash -n scripts/test-hermes-nemo-relay-rendered-manifest.sh
+kustomize build --enable-helm components/ai/hermes-agent >/dev/null
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 3: Review the final diff**
+
+Confirm only the Hermes ConfigMap, Helm values, rendered-manifest test, and this design/plan documentation changed. Confirm no secret values, new Gateway API resources, or changes to Alloy, Tempo, Grafana, VolSync, or model provider configuration.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add \
+  components/ai/hermes-agent/configmap.yaml \
+  components/ai/hermes-agent/values.yaml \
+  scripts/test-hermes-nemo-relay-rendered-manifest.sh \
+  docs/superpowers/specs/2026-07-02-hermes-nemo-relay-observability-design.md \
+  docs/superpowers/plans/2026-07-02-hermes-nemo-relay-observability.md
+git commit -m "feat: export Hermes traces through NeMo Relay"
+```

--- a/docs/superpowers/specs/2026-07-02-hermes-nemo-relay-observability-design.md
+++ b/docs/superpowers/specs/2026-07-02-hermes-nemo-relay-observability-design.md
@@ -1,0 +1,51 @@
+# Hermes NeMo Relay Observability Design
+
+## Goal
+
+Export Hermes Agent lifecycle, LLM, tool, approval, and subagent telemetry as OpenInference OTLP traces through Alloy to Tempo and Grafana.
+
+## Context
+
+The published Hermes image from `agent-platform-custom` commit `85d48a6` installs `nemo-relay==0.3.0` into Hermes's runtime virtual environment and validates the bundled `observability/nemo_relay` plugin. Home-Ops currently runs that image as the `hermes-agent` Deployment in namespace `ai` with `hermes gateway run`.
+
+Alloy already accepts OTLP HTTP on `alloy.observability.svc.cluster.local:4318` and forwards traces to Tempo. Grafana already uses Tempo as a datasource. No NeMo Relay gateway, Service, HTTPRoute, or external credential is required for this telemetry-only integration.
+
+## Decision
+
+Use the in-process Hermes `observability/nemo_relay` plugin, not the `nemo-relay hermes` CLI wrapper or a standalone Relay gateway.
+
+The CLI wrapper is intended for local interactive processes: it creates a temporary loopback gateway and modifies local hook configuration. The in-process plugin matches the existing long-running, ConfigMap-driven Kubernetes Deployment and emits OpenInference-compatible OTLP directly.
+
+## Configuration
+
+1. Enable `observability/nemo_relay` in the existing Hermes plugin list in `hermes-agent-config`.
+2. Add a `nemo-relay-plugins.toml` entry to the same ConfigMap. It enables only the NeMo Relay `observability` component and its `openinference` exporter.
+3. Configure the exporter with `http_binary` transport and endpoint `http://alloy.observability.svc.cluster.local:4318/v1/traces`.
+4. Set stable resource identity using `service_name = "hermes-agent"` and `service_namespace = "ai"`.
+5. Mount that ConfigMap key read-only at `/opt/data/nemo-relay-plugins.toml` and set `HERMES_NEMO_RELAY_PLUGINS_TOML` to that path.
+6. Update the deployed Hermes image to the CI-produced immutable tag `20260702184336-85d48a6-oci`.
+
+## Explicit Non-Goals
+
+- Do not change `HERMES_BASE_URL`, providers, or model traffic routing.
+- Do not add a NeMo Relay sidecar, Deployment, Service, HTTPRoute, or ExternalSecret.
+- Do not enable ATOF or ATIF file exporters. They would consume the Hermes PVC and require independent retention and backup policy.
+- Do not alter Alloy, Tempo, Grafana, Gateway API, or VolSync configuration.
+
+## Failure Behavior
+
+NeMo Relay exporter delivery failures are fail-open for Hermes work according to NVIDIA's observability configuration: telemetry export errors are reported by the exporter without blocking agent execution. Invalid plugin configuration fails initialization, so rendered-manifest tests must assert the exact component kind, exporter type, endpoint, and mount contract before Argo sync.
+
+## Verification
+
+- A focused rendered-manifest contract test verifies the image tag, plugin enablement, TOML content, environment variable, and ConfigMap mount.
+- Kustomize/Helm rendering verifies the component is structurally valid.
+- After Argo sync, one Hermes request must produce a `hermes-agent` trace in Tempo, visible through the existing Grafana Tempo datasource.
+
+## Sources
+
+- NVIDIA NeMo Relay Hermes integration: https://docs.nvidia.com/nemo/relay/nemo-relay-cli/hermes
+- NVIDIA NeMo Relay observability configuration: https://docs.nvidia.com/nemo/relay/observability-plugin/configuration
+- Hermes plugin at the image's pinned upstream release: https://github.com/NousResearch/hermes-agent/tree/2bd1977d8fad185c9b4be47884f7e87f1add0ce3/plugins/observability/nemo_relay
+- Home-Ops Hermes component: `components/ai/hermes-agent/`
+- Home-Ops Alloy receiver: `components/observability/alloy/values.yaml`

--- a/scripts/test-hermes-nemo-relay-rendered-manifest.sh
+++ b/scripts/test-hermes-nemo-relay-rendered-manifest.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly HERMES_COMPONENT="${ROOT_DIR}/components/ai/hermes-agent"
+readonly HERMES_IMAGE="gitea.a113.casa/vpogu/agent-platform-hermes-agent:20260702184336-85d48a6-oci"
+export HERMES_IMAGE
+readonly NEMO_RELAY_PLUGINS_PATH="/opt/data/nemo-relay-plugins.toml"
+export NEMO_RELAY_PLUGINS_PATH
+readonly NEMO_RELAY_PLUGINS_TOML=$'version = 1\n\n[[components]]\nkind = "observability"\nenabled = true\n\n[components.config]\nversion = 1\n\n[components.config.openinference]\nenabled = true\ntransport = "http_binary"\nendpoint = "http://alloy.observability.svc.cluster.local:4318/v1/traces"\nservice_name = "hermes-agent"\nservice_namespace = "ai"\ninstrumentation_scope = "hermes-nemo-relay"\ntimeout_millis = 3000\n\n[components.config.openinference.resource_attributes]\n"deployment.environment" = "talos"'
+umask 077
+readonly manifest="$(mktemp)"
+trap 'rm -f -- "${manifest}"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+resource_count() {
+  local kind="$1"
+  local name="$2"
+
+  yq ea -r "[select(.kind == \"${kind}\" and .metadata.name == \"${name}\")] | length" "${manifest}"
+}
+
+hermes_app_container_count() {
+  yq ea -r '
+
+    [
+      select(.kind == "Deployment" and .metadata.name == "hermes-agent")
+      | .spec.template.spec.containers[]?
+      | select(.image | test("^gitea\\.a113\\.casa/vpogu/agent-platform-hermes-agent:"))
+    ] | length
+
+  ' "${manifest}"
+}
+
+hermes_app_image_count() {
+  yq ea -r '
+
+    [
+      select(.kind == "Deployment" and .metadata.name == "hermes-agent")
+      | .spec.template.spec.containers[]?
+      | select(.image == strenv(HERMES_IMAGE))
+    ] | length
+
+  ' "${manifest}"
+}
+
+hermes_init_container_count() {
+  yq ea -r '
+
+    [
+      select(.kind == "Deployment" and .metadata.name == "hermes-agent")
+      | .spec.template.spec.initContainers[]?
+      | select(.image | test("^gitea\\.a113\\.casa/vpogu/agent-platform-hermes-agent:"))
+    ] | length
+
+  ' "${manifest}"
+}
+
+hermes_init_image_count() {
+  yq ea -r '
+
+    [
+      select(.kind == "Deployment" and .metadata.name == "hermes-agent")
+      | .spec.template.spec.initContainers[]?
+      | select(.image == strenv(HERMES_IMAGE))
+    ] | length
+
+  ' "${manifest}"
+}
+
+hermes_app_env_count() {
+  yq ea -r '
+
+    [
+      select(.kind == "Deployment" and .metadata.name == "hermes-agent")
+      | .spec.template.spec.containers[]?
+      | select(.image | test("^gitea\\.a113\\.casa/vpogu/agent-platform-hermes-agent:"))
+      | .env[]?
+      | select(.name == "HERMES_NEMO_RELAY_PLUGINS_TOML" and .value == strenv(NEMO_RELAY_PLUGINS_PATH))
+    ] | length
+
+  ' "${manifest}"
+}
+
+hermes_nemo_relay_plugin_count() {
+  yq ea -r '
+    [
+      select(.kind == "ConfigMap" and .metadata.name == "hermes-agent-config")
+      | .data["config.yaml"]
+      | from_yaml
+      | .plugins.enabled[]?
+      | select(. == "observability/nemo_relay")
+    ] | length
+  ' "${manifest}"
+}
+
+hermes_config_volume_count() {
+  yq ea -r '
+    [
+      select(.kind == "Deployment" and .metadata.name == "hermes-agent")
+      | .spec.template.spec.volumes[]?
+      | select(.name == "config" and .configMap.name == "hermes-agent-config")
+    ] | length
+  ' "${manifest}"
+}
+
+hermes_plugin_mount_count() {
+  yq ea -r '
+
+    [
+      select(.kind == "Deployment" and .metadata.name == "hermes-agent")
+      | .spec.template.spec.containers[]?
+      | select(.image | test("^gitea\\.a113\\.casa/vpogu/agent-platform-hermes-agent:"))
+      | .volumeMounts[]?
+      | select(
+          .name == "config"
+          and .mountPath == strenv(NEMO_RELAY_PLUGINS_PATH)
+          and .subPath == "nemo-relay-plugins.toml"
+          and .readOnly == true
+        )
+    ] | length
+
+  ' "${manifest}"
+}
+
+kustomize build --enable-helm "${HERMES_COMPONENT}" >"${manifest}"
+
+[[ "$(resource_count Deployment hermes-agent)" == "1" ]] || fail "rendered Hermes Deployment is missing or ambiguous"
+[[ "$(resource_count ConfigMap hermes-agent-config)" == "1" ]] || fail "rendered Hermes ConfigMap is missing or ambiguous"
+[[ "$(hermes_app_container_count)" == "1" ]] || fail "rendered Hermes application container is missing or ambiguous"
+
+[[ "$(hermes_init_container_count)" == "2" ]] || fail "rendered Hermes init containers are missing or ambiguous"
+
+[[ "$(hermes_app_image_count)" == "1" ]] || fail "rendered Hermes application image must use ${HERMES_IMAGE} exactly once"
+
+[[ "$(hermes_init_image_count)" == "2" ]] || fail "rendered Hermes init containers must use ${HERMES_IMAGE}"
+[[ "$(hermes_nemo_relay_plugin_count)" == "1" ]] || fail "rendered Hermes configuration must enable observability/nemo_relay"
+[[ "$(
+  yq ea -r '
+    select(.kind == "ConfigMap" and .metadata.name == "hermes-agent-config")
+    | .data["nemo-relay-plugins.toml"]
+  ' "${manifest}"
+)" == "${NEMO_RELAY_PLUGINS_TOML}" ]] || fail "NeMo Relay OpenInference ConfigMap entry missing or invalid"
+[[ "$(hermes_app_env_count)" == "1" ]] || fail "rendered Hermes application container must set HERMES_NEMO_RELAY_PLUGINS_TOML"
+[[ "$(hermes_config_volume_count)" == "1" ]] || fail "rendered Hermes ConfigMap volume is missing or ambiguous"
+[[ "$(hermes_plugin_mount_count)" == "1" ]] || fail "rendered Hermes application container must mount the NeMo Relay ConfigMap key read-only"
+
+printf 'PASS: rendered Hermes image, NeMo Relay OpenInference config, environment, and ConfigMap mount are consistent\n'


### PR DESCRIPTION
## Summary
- deploy the verified NeMo Relay-enabled Hermes image
- enable Hermes in-process `observability/nemo_relay`
- export OpenInference OTLP traces through Alloy to Tempo/Grafana
- add a rendered-manifest contract test

## Verification
- `bash scripts/test-hermes-nemo-relay-rendered-manifest.sh`
- `bash -n scripts/test-hermes-nemo-relay-rendered-manifest.sh`
- `kustomize build --enable-helm components/ai/hermes-agent >/dev/null`

No provider routing, secrets, storage, ingress, Alloy, Tempo, or Grafana configuration changed.