### PR TITLE
Deploy private SearXNG search service

### DIFF
--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -612,6 +612,14 @@ applications:
     source:
       path: components/ai/headroom-codex
 
+  searxng:
+    annotations:
+      argocd.argoproj.io/sync-wave: "20"
+    destination:
+      namespace: ai
+    source:
+      path: components/ai/searxng
+
   valetudopng:
     annotations:
       argocd.argoproj.io/sync-wave: "20"

--- a/components/ai/searxng/externalsecret.yaml
+++ b/components/ai/searxng/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: searxng
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: searxng-secret
+    template:
+      engineVersion: v2
+      data:
+        SEARXNG_SECRET: "{{ .SEARXNG_SECRET }}"
+  dataFrom:
+    - extract:
+        key: searxng

--- a/components/ai/searxng/http-route.yaml
+++ b/components/ai/searxng/http-route.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: &app searxng
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+spec:
+  parentRefs:
+    - name: ${GATEWAY_NAME}
+      namespace: ${GATEWAY_NAMESPACE}
+      sectionName: https
+  hostnames: ["searxng.${CLUSTER_DOMAIN}"]
+  rules:
+    - backendRefs:
+        - name: *app
+          port: 8080

--- a/components/ai/searxng/kustomization.yaml
+++ b/components/ai/searxng/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+resources:
+  - ./externalsecret.yaml
+  - ./http-route.yaml
+helmCharts:
+  - name: app-template
+    releaseName: searxng
+    namespace: ai
+    repo: oci://ghcr.io/bjw-s-labs/helm
+    version: "5.0.1"
+    valuesFile: values.yaml
+configMapGenerator:
+  - name: searxng-settings
+    files:
+      - settings.yml
+generatorOptions:
+ disableNameSuffixHash: true

--- a/components/ai/searxng/settings.yml
+++ b/components/ai/searxng/settings.yml
@@ -1,0 +1,13 @@
+use_default_settings: true
+
+server:
+  secret_key: "__SEARXNG_SECRET__"
+  bind_address: "0.0.0.0"
+  port: 8080
+  limiter: false
+  public_instance: false
+
+search:
+  formats:
+    - html
+    - json

--- a/components/ai/searxng/values.yaml
+++ b/components/ai/searxng/values.yaml
@@ -1,0 +1,117 @@
+controllers:
+  searxng:
+    replicas: 1
+    strategy: Recreate
+    annotations:
+      configmap.reloader.stakater.com/reload: searxng-settings
+      secret.reloader.stakater.com/reload: searxng-secret
+    pod:
+      securityContext:
+        fsGroup: 977
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 977
+        runAsNonRoot: true
+        runAsUser: 977
+        seccompProfile:
+          type: RuntimeDefault
+    initContainers:
+      render-settings:
+        image:
+          repository: public.ecr.aws/docker/library/busybox
+          tag: 1.38.0
+        command:
+          - /bin/sh
+          - -c
+          - umask 077; escaped_secret=$(printf '%s' "$SEARXNG_SECRET" | sed 's/[\/&\\]/\\&/g'); sed "s/__SEARXNG_SECRET__/${escaped_secret}/g" /config-template/settings.yml > /runtime-config/settings.yml
+        env:
+          SEARXNG_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: searxng-secret
+                key: SEARXNG_SECRET
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+    containers:
+      app:
+        image:
+          repository: ghcr.io/searxng/searxng
+          tag: 2026.7.2-67973783d
+        env:
+          SEARXNG_SETTINGS_PATH: /runtime-config/settings.yml
+        probes:
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 8080
+              failureThreshold: 30
+              periodSeconds: 5
+              timeoutSeconds: 5
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 8080
+              failureThreshold: 3
+              periodSeconds: 10
+              timeoutSeconds: 5
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 8080
+              failureThreshold: 3
+              periodSeconds: 30
+              timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+service:
+  app:
+    controller: searxng
+    type: ClusterIP
+    ports:
+      http:
+        port: 8080
+persistence:
+  config-template:
+    type: configMap
+    name: searxng-settings
+    advancedMounts:
+      searxng:
+        render-settings:
+          - path: /config-template
+            readOnly: true
+  runtime-config:
+    type: emptyDir
+    advancedMounts:
+      searxng:
+        render-settings:
+          - path: /runtime-config
+        app:
+          - path: /runtime-config
+  config:
+    type: emptyDir
+    advancedMounts:
+      searxng:
+        app:
+          - path: /etc/searxng
+  cache:
+    type: emptyDir
+    advancedMounts:
+      searxng:
+        app:
+          - path: /var/cache/searxng

--- a/tests/searxng-render.test.sh
+++ b/tests/searxng-render.test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+rendered_manifest=$(mktemp "${TMPDIR:-/tmp}/searxng-render.XXXXXX")
+render_test_dir=$(mktemp -d "${TMPDIR:-/tmp}/searxng-render-test.XXXXXX")
+config_template_dir="$render_test_dir/config-template"
+runtime_config_dir="$render_test_dir/runtime-config"
+trap 'rm -f "$rendered_manifest"; rm -rf "$render_test_dir"' EXIT HUP INT TERM
+
+if ! command -v kustomize >/dev/null 2>&1; then
+  printf 'FAIL: kustomize is required to render SearXNG manifests.\n' >&2
+  exit 1
+fi
+
+kustomize build --enable-helm "$repo_root/components/ai/searxng" >"$rendered_manifest"
+render_command_failure=0
+init_command=$(awk '
+  function indentation(line) {
+    match(line, /^[[:space:]]*/)
+    return RLENGTH
+  }
+
+  /^---[[:space:]]*$/ {
+    in_deployment = 0
+    in_init_containers = 0
+    next
+  }
+
+  /^kind:[[:space:]]*/ {
+    in_deployment = ($0 ~ /^kind:[[:space:]]*Deployment[[:space:]]*$/)
+    in_init_containers = 0
+    next
+  }
+
+  in_deployment && /^[[:space:]]+initContainers:[[:space:]]*$/ {
+    init_containers_indentation = indentation($0)
+    in_init_containers = 1
+    next
+  }
+
+  in_init_containers && $0 !~ /^[[:space:]]*$/ && indentation($0) <= init_containers_indentation && $0 !~ /^[[:space:]]*-[[:space:]]/ {
+    in_init_containers = 0
+  }
+
+  in_command {
+    if ($0 ~ /^[[:space:]]*$/) {
+      next
+    }
+
+    if (indentation($0) > command_indentation && $0 !~ /^[[:space:]]*-[[:space:]]/) {
+      continuation = $0
+      sub(/^[[:space:]]*/, "", continuation)
+      command = command " " continuation
+      next
+    }
+
+    print command
+    emitted_command = 1
+    exit
+  }
+
+  in_init_containers && /^[[:space:]]*-[[:space:]]*-c[[:space:]]*$/ {
+    shell_command_follows = 1
+    next
+  }
+
+  in_init_containers && shell_command_follows && /^[[:space:]]*-[[:space:]]*/ {
+    command = $0
+    command_indentation = indentation(command)
+    sub(/^[[:space:]]*-[[:space:]]*/, "", command)
+    in_command = 1
+    shell_command_follows = 0
+  }
+
+  END {
+    if (in_command && !emitted_command) {
+      print command
+    }
+  }
+' "$rendered_manifest")
+
+if [ -z "$init_command" ]; then
+  printf 'FAIL: could not locate the rendered SearXNG init-container command.\n' >&2
+  render_command_failure=1
+else
+  mkdir -p "$config_template_dir" "$runtime_config_dir"
+  cp "$repo_root/components/ai/searxng/settings.yml" "$config_template_dir/settings.yml"
+  synthetic_secret='render/secret&pipe|backslash\value'
+  runtime_init_command=${init_command//\/config-template/$config_template_dir}
+  runtime_init_command=${runtime_init_command//\/runtime-config/$runtime_config_dir}
+
+  if ! SEARXNG_SECRET="$synthetic_secret" sh -c "$runtime_init_command" >"$render_test_dir/init-command.stdout" 2>"$render_test_dir/init-command.stderr"; then
+    printf 'FAIL: rendered init-container command cannot render a secret containing sed-special characters.\n' >&2
+    render_command_failure=1
+  elif [ ! -r "$runtime_config_dir/settings.yml" ]; then
+    printf 'FAIL: rendered init-container command did not write the settings file.\n' >&2
+    render_command_failure=1
+  else
+    rendered_secret=$(awk '
+      /^[[:space:]]*secret_key:[[:space:]]*/ {
+        value = $0
+        sub(/^[[:space:]]*secret_key:[[:space:]]*/, "", value)
+        sub(/^"/, "", value)
+        sub(/"$/, "", value)
+        print value
+        exit
+      }
+    ' "$runtime_config_dir/settings.yml")
+
+    if [ "$rendered_secret" != "$synthetic_secret" ]; then
+      printf 'FAIL: rendered init-container command changed a secret containing sed-special characters.\n' >&2
+      render_command_failure=1
+    fi
+  fi
+fi
+
+configmap_names=$(awk '
+  function save_document() {
+    if (kind == "ConfigMap") {
+      print name
+    }
+  }
+
+  /^---[[:space:]]*$/ {
+    save_document()
+    kind = ""
+    name = ""
+    in_metadata = 0
+    next
+  }
+
+  /^kind:[[:space:]]*/ {
+    kind = $0
+    sub(/^kind:[[:space:]]*/, "", kind)
+    next
+  }
+
+  /^metadata:[[:space:]]*$/ {
+    in_metadata = 1
+    next
+  }
+
+  in_metadata && /^[^[:space:]]/ {
+    in_metadata = 0
+  }
+
+  in_metadata && /^[[:space:]]+name:[[:space:]]*/ {
+    name = $0
+    sub(/^[[:space:]]+name:[[:space:]]*/, "", name)
+    sub(/[[:space:]]+$/, "", name)
+    in_metadata = 0
+  }
+
+  END {
+    save_document()
+  }
+' "$rendered_manifest")
+
+reloader_values=$(awk '
+  function save_document() {
+    if (kind == "Deployment" && reloader_value_found) {
+      print reloader_value
+    }
+  }
+
+  /^---[[:space:]]*$/ {
+    save_document()
+    kind = ""
+    in_metadata = 0
+    in_annotations = 0
+    reloader_value_found = 0
+    reloader_value = ""
+    next
+  }
+
+  /^kind:[[:space:]]*/ {
+    kind = $0
+    sub(/^kind:[[:space:]]*/, "", kind)
+    next
+  }
+
+  /^metadata:[[:space:]]*$/ {
+    in_metadata = 1
+    next
+  }
+
+  in_metadata && /^[^[:space:]]/ {
+    in_metadata = 0
+    in_annotations = 0
+  }
+
+  in_metadata && /^  annotations:[[:space:]]*$/ {
+    in_annotations = 1
+    next
+  }
+
+  in_annotations && /^  [^[:space:]]/ {
+    in_annotations = 0
+  }
+
+  in_annotations && /^    configmap\.reloader\.stakater\.com\/reload:[[:space:]]*/ {
+    reloader_value = $0
+    sub(/^    configmap\.reloader\.stakater\.com\/reload:[[:space:]]*/, "", reloader_value)
+    sub(/[[:space:]]+$/, "", reloader_value)
+    reloader_value_found = 1
+  }
+
+  END {
+    save_document()
+  }
+' "$rendered_manifest")
+
+failures=$render_command_failure
+
+if ! printf '%s\n' "$configmap_names" | grep -Fx 'searxng-settings' >/dev/null; then
+  printf 'FAIL: expected ConfigMap metadata.name to be searxng-settings; rendered ConfigMap names:\n%s\n' "${configmap_names:-<none>}" >&2
+  failures=1
+fi
+
+hashed_configmap_names=$(printf '%s\n' "$configmap_names" | grep -E '^searxng-settings-[[:alnum:]]+$' || true)
+if [ -n "$hashed_configmap_names" ]; then
+  printf 'FAIL: generated ConfigMap hash suffix is not allowed: %s\n' "$hashed_configmap_names" >&2
+  failures=1
+fi
+
+if [ "$reloader_values" != 'searxng-settings' ]; then
+  printf 'FAIL: expected Deployment configmap.reloader.stakater.com/reload to equal searxng-settings; rendered values:\n%s\n' "${reloader_values:-<none>}" >&2
+  failures=1
+fi
+
+if [ "$failures" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
Adds the private AI-namespace SearXNG service and internal HTTPS route. The ExternalSecret-backed init renderer keeps the secret runtime-only, JSON search is enabled, and manifest tests cover ConfigMap naming plus special-character-safe secret rendering. Live reconciliation remains pending creation of the 1Password searxng secret item.