### PR TITLE
(chore): bump it-tools image 2023.12.21-5ed3693 → 2024.10.22-7ca5933

### DIFF
--- a/components/default/it-tools/values.yaml
+++ b/components/default/it-tools/values.yaml
@@ -7,7 +7,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/corentinth/it-tools
-          tag: 2023.12.21-5ed3693
+          tag: 2024.10.22-7ca5933
         env:
           TZ: America/New_York
         probes:


### PR DESCRIPTION
## Summary

Advance `it-tools` (non-production workload) from `2023.12.21-5ed3693` to `2024.10.22-7ca5933`.

## Image Change

| Field | Value |
|---|---|
| Repository | `ghcr.io/corentinth/it-tools` |
| Prior tag | `2023.12.21-5ed3693` |
| New tag | `2024.10.22-7ca5933` |
| Release | https://github.com/CorentinTh/it-tools/releases/tag/v2024.10.22-7ca5933 |
| Prerelease | false |
| Published | 2024-10-22 |

## Verification

- **Source verified**: Official GitHub release `v2024.10.22-7ca5933` (non-prerelease, stable)
- **GHCR image confirmed** in release notes: `ghcr.io/corentinth/it-tools:2024.10.22-7ca5933`
- **YAML validation**: PASS — all 3 files in `components/default/it-tools/` validated with `yq`
- **Scope**: Exactly 1 line changed in `components/default/it-tools/values.yaml`
- **Protected components untouched**: Forge, Hermes, headroom, headroom-codex all preserved

## Changelog highlights (from release notes)

- New tool: Regex Tester (and Cheatsheet)
- New tool: Markdown to HTML
- New tool: Email normalizer
- New tools: JSON to XML and XML to JSON
- lorem-ipsum: add button to refresh text