### PR TITLE
(feat): add Forge workflow skills

### DIFF
--- a/components/ai/forge/configmap.yaml
+++ b/components/ai/forge/configmap.yaml
@@ -52,6 +52,7 @@ data:
       - id: plan
         type: agent
         role: planner
+        skills: [explore-first]
         # Pick the model per node. Omit to use FORGE_DEFAULT_MODEL.
         model: aws/anthropic/bedrock-claude-opus-4-8
         timeout_minutes: 10
@@ -67,10 +68,12 @@ data:
           type: agent
           role: implementer
           rules: [ponytail, codebase-design]
+          skills: [verify-loop, defensive-coding, secret-scan]
       - id: ai-review
         type: agent
         role: reviewer
         rules: [codebase-design]
+        skills: [security, impact-analysis]
         depends_on: [implement]
         # Deliberately a different model than the implementer for fresh eyes.
         model: nvidia/zai-org/glm-5.2
@@ -87,9 +90,11 @@ data:
           type: agent
           role: implementer
           rules: [ponytail, codebase-design]
+          skills: [verify-loop, secret-scan]
       - id: open-pr
         type: agent
         role: pr-opener
+        skills: [secret-scan]
         # implement + ai-review are already ancestors via fix-loop; the extra
         # edges pull their notes into this node's message for the PR body.
         depends_on: [implement, ai-review, fix-loop]
@@ -167,6 +172,68 @@ data:
           The interface is the test surface — callers and tests cross the same seam.
           One adapter = hypothetical seam. Two adapters = real seam. Don't add a seam unless two adapters are justified.
           Accept dependencies, don't create them. Return values, not side effects.
+
+      explore-first:
+        description: "Read → reproduce → root-cause → plan. No coding until root cause is confirmed."
+        content: |
+          Before writing a plan or proposing changes:
+          1. Read the task fully. Identify the symptom vs. the root cause.
+          2. Search the codebase for every caller/owner of the affected function or module.
+          3. Create a reproduction script or failing test to confirm the problem is real.
+          4. Identify the single correct layer where the behavior is defined — fix there,
+             not in all callers.
+          5. Output a short bullet plan: files to touch, approach, edge cases.
+             Do NOT start coding until the plan is written.
+
+      verify-loop:
+        description: "Rerun reproduction after every change. Never mark done until original failure is gone and no tests broke."
+        content: |
+          After every code change:
+          - Rerun the reproduction script or failing test. Never assume a fix worked.
+          - Do not suppress errors with try/except to make tests pass. Fix the root cause.
+          - Confirm: (a) original failure gone, (b) no existing tests newly broken,
+            (c) at least one edge case checked.
+          - Run targeted tests during iteration. Run full suite before final commit only.
+
+      defensive-coding:
+        description: "Validate at boundaries, implement __hash__ with __eq__, log silenced exceptions, normalize iterables before serialization."
+        content: |
+          - Validate and normalize inputs at the entry point, not deep in helpers.
+          - When implementing __eq__, always implement __hash__. Equal objects must hash equal.
+          - Normalize dict_keys/dict_values to list/tuple before deep-copy or serialization.
+          - Never bare except without logging the exception with exc_info=True.
+          - Provide clear error messages that include the offending value.
+          - Never assume an attribute or config value is present — check explicitly.
+
+      secret-scan:
+        description: "Scan the diff for hardcoded secrets before any commit or push."
+        content: |
+          Before committing or pushing, scan the full diff for:
+          - API keys, tokens, passwords, private keys (any string matching key/token/secret/password
+            patterns assigned a string literal)
+          - Credentials echoed into logs, result.json, or test fixtures
+          If found: remove the secret, use an environment variable or secret store instead.
+          Never commit a secret even in a test file.
+
+      impact-analysis:
+        description: "Trace all callers of modified functions — are sibling call sites also broken?"
+        content: |
+          For every function, method, or module changed in this diff:
+          1. Find all call sites in the codebase (grep/search).
+          2. Confirm the fix applies to ALL of them, not just the one the ticket named.
+          3. Flag any sibling call site where the same bug still exists after the patch.
+          A patch that fixes one caller and leaves all others broken is worse than no patch.
+
+      security:
+        description: "Review changes for security regressions before approval."
+        content: |
+          Review every change for security impact:
+          - Validate untrusted input at boundaries and reject unsafe values clearly.
+          - Do not log secrets, credentials, tokens, private data, or authorization headers.
+          - Preserve least privilege for filesystem, network, Kubernetes RBAC, and cloud access.
+          - Avoid injection vulnerabilities in shell commands, SQL, templates, YAML, and URLs.
+          - Fail closed on authorization, authentication, and policy checks.
+          - If a risk remains, call it out explicitly with the affected file and mitigation.
   rules.yaml: |-
     rules:
       ponytail:


### PR DESCRIPTION
## Summary
- add five research-backed Forge workflow skills to the ConfigMap skills registry
- add the security skill because it is referenced by ai-review and was not present in the current branch
- wire explore-first, verify-loop, defensive-coding, secret-scan, security, and impact-analysis to the implement workflow nodes

## Verification
- yq parsed embedded implement.yaml and skills.yaml successfully
- git diff --check passed
- kubeconform passed with local schema/command shims due sandbox proxy blocking upstream schema and release asset downloads


## ✅ Done

### What shipped
- `components/ai/forge/configmap.yaml` — added 6 new skill entries (5 requested + `security`) to the embedded `skills.yaml` block, and wired `skills:` references onto the `plan`, `implement`, `ai-review`, `fix-loop`, and `open-pr` nodes inside the embedded `implement.yaml` block.

### Why
_Give Forge's AI workflow nodes research-backed behavioral skills (from SWE-bench top performers and Claude Code/OpenHands practices) so each stage of the plan → implement → review → fix loop follows a disciplined process instead of relying on model defaults._

### 👩‍🏫 Tutor notes

**`configmap.yaml: skills.yaml` block — new skill definitions**
What it does: Adds five (plus one extra, `security`) named entries under the `skills:` map, each with a `description` (short summary shown to the agent) and a `content` (a YAML block-literal string, `|`, holding the actual instructions the LLM reads verbatim).
Concept: this is a **prompt library / registry pattern** — reusable, named chunks of instruction text stored centrally instead of duplicated inline in every node. It's analogous to a shared "mixin" or "trait" that multiple call sites can opt into.
Why this way: keeping skills in one map lets many workflow nodes reference the same text by name (`skills: [secret-scan]`) rather than copy-pasting the same paragraph into every node definition — one edit updates every consumer.

**`configmap.yaml: implement.yaml` block — `skills:` field added to node specs**
What it does: Each node (`plan`, `implement`, `ai-review`, `fix-loop`, `open-pr`) gets a new `skills: [...]` list alongside its existing `role`/`model`/`rules` fields, telling the workflow engine which prompt snippets to inject for that specific agent invocation.
Concept: this is **declarative configuration / composition over inheritance** — behavior is assembled by listing which skills apply to a node, rather than hardcoding logic in `workflow.py`. The Python engine already knows how to read `skills:` (per the task constraints), so this is pure data wiring, no code change.
Why this way: attaching skills per-node (rather than globally) lets each stage of the pipeline get exactly the guidance relevant to its job — e.g. the planner gets `explore-first` (read-before-code discipline) while the implementer gets `verify-loop`/`defensive-coding`/`secret-scan` (write-and-verify discipline), avoiding one-size-fits-all prompting.

**`configmap.yaml: security` skill (added beyond the 5 requested)**
What it does: A new `security` skill describing what a reviewer should check for (input validation, no secret logging, least privilege, injection risks, fail-closed auth) — wired onto the `ai-review` node.
Concept: this is a **forward dependency shim** — the task spec anticipated that a separate task (#125) might already add this skill via its own PR, and instructed adding it locally if it wasn't merged yet, to avoid `ai-review`'s `skills: [security, impact-analysis]` reference pointing at an undefined skill name.
Why this way: adding the stub here (rather than waiting on task #125 to merge first) keeps this PR self-contained and passing validation (`kubeconform`/YAML parse) regardless of merge order; if #125 lands with an identical or different definition, the two can be reconciled later without blocking this change.

**`configmap.yaml` — YAML indentation and block-literal discipline**
What it does: All new content matches the existing 6-space indentation for skill entries under `skills.yaml`, and uses YAML's `|` block scalar so multi-line instruction text (with its own internal indentation) is preserved literally rather than being reflowed or requiring escape characters.
Concept: **indentation-sensitive embedded configuration** — the ConfigMap stores YAML-as-a-string inside another YAML file, so a single misaligned space breaks parsing for the *inner* document even though the *outer* ConfigMap YAML looks fine.
Why this way: matching existing formatting exactly (rather than reformatting) minimizes diff noise and reduces risk of introducing a subtle indentation bug; the implementer verified this with `yq '.data."implement.yaml" | from_yaml'` and `yq '.data."skills.yaml" | from_yaml'` to parse the *inner* embedded YAML, not just the outer file.
