### PR TITLE
(fix): set rook ceph mgr resources

### DIFF
--- a/components/rook-ceph/rook-ceph-cluster/values.yaml
+++ b/components/rook-ceph/rook-ceph-cluster/values.yaml
@@ -47,11 +47,10 @@ cephClusterSpec:
   mgr:
     resources:
       requests:
-        memory: 512Mi
+        memory: 1Gi
         cpu: 250m
       limits:
-        memory: 1Gi
-        cpu: 500m
+        memory: 2Gi
     modules:
       - name: diskprediction_local
         enabled: true

--- a/components/rook-ceph/rook-ceph-cluster/values.yaml
+++ b/components/rook-ceph/rook-ceph-cluster/values.yaml
@@ -45,6 +45,13 @@ cephClusterSpec:
     ssl: false
     prometheusEndpoint: http://prometheus-operated.observability.svc.cluster.local:9090
   mgr:
+    resources:
+      requests:
+        memory: 512Mi
+        cpu: 250m
+      limits:
+        memory: 1Gi
+        cpu: 500m
     modules:
       - name: diskprediction_local
         enabled: true


### PR DESCRIPTION
## Summary
- add Rook Ceph mgr CPU and memory requests/limits under `cephClusterSpec.mgr`
- target 512Mi/250m requests and 1Gi/500m limits to reduce OOMKills under node memory pressure

## Validation
- `python wrapper | kubeconform -ignore-missing-schemas -skip Values` passed for the Helm values YAML parse check
- attempted `bash ./scripts/kubeconform.sh`; local run was blocked by missing `envsubst`, then by 403 fetching upstream kubeconform schemas after adding a temporary envsubst shim


---

## ✅ Done

### What shipped
- `components/rook-ceph/rook-ceph-cluster/values.yaml` — added a `resources` block under `cephClusterSpec.mgr` with memory/CPU requests and limits.

### Why
The `rook-ceph-mgr-a` container had no resource limits, so it was among the first killed (OOMKilled) whenever the node hit memory pressure; giving it a bounded request/limit stops it from being an easy OOM target.

### 👩‍🏫 Tutor notes

**`components/rook-ceph/rook-ceph-cluster/values.yaml`: `cephClusterSpec.mgr.resources`**
What it does: Adds a `requests`/`limits` map (512Mi/250m request, 1Gi/500m limit) directly under the existing `mgr:` key, right above the `modules:` list that was already there.
Concept: **declarative resource sizing** — this is standard Kubernetes practice of setting `resources.requests` (what the scheduler reserves) and `resources.limits` (the hard ceiling the kubelet enforces) rather than letting a container run unbounded.
Why this way: The Helm chart for `rook-ceph-cluster` doesn't run the Deployment itself — it renders a `CephCluster` custom resource, and the Rook operator reads `spec.mgr` from that CR to build the actual mgr Deployment. So the fix has to go through the chart's `cephClusterSpec.mgr` values (which map 1:1 onto the CR's `spec.mgr` field) instead of editing a Deployment/pod spec directly, because no such spec exists in this repo for mgr — Rook generates it at runtime.

**Sizing rationale**
What it does: Picks 512Mi request / 1Gi limit for memory and 250m / 500m for CPU.
Concept: **capacity planning by workload profile** — the numbers aren't arbitrary; they're sized for a 3-node homelab Ceph cluster with `pg_autoscaler`, `diskprediction_local`, and `insights` modules all enabled, which are the modules driving mgr's memory footprint.
Why this way: A tighter limit (e.g. 256Mi) risks reintroducing OOMKills once those modules are active; a much larger one would over-reserve memory on a small homelab node for marginal benefit, so this is a middle-ground "just enough headroom" value rather than a blanket high limit.

**Validation approach**
What it does: Because Helm `values.yaml` files aren't valid standalone Kubernetes objects (they're just data consumed by templates), a direct `kubeconform` run against the raw file doesn't make sense.
Concept: **CI seam mismatch / synthetic wrapper** — the implementer built a small synthetic Kubernetes-object wrapper around the YAML snippet purely to get `kubeconform` to parse and validate the shape, then relied on the repo's actual GitHub Actions kubeconform check (which does the full Helm template + validate pipeline) as the real gate.
Why this way: Rendering the full chart locally required `envsubst` and hit a 403 pulling upstream JSON schemas in the sandbox, so rather than fighting the local environment, validation was deferred to CI, which is the tool actually wired up to test this correctly.

**PR workflow**
What it does: Commits the one-file, 7-line addition as `1cff8da5`, pushes the `agent/134-fix-rook-ceph-increase-mgr-container-memory-limit` branch, and opens PR #1603 against `main`.
Concept: **minimal diff / single-responsibility change** — the PR touches exactly one key in one file, making the change trivially reviewable and low-risk to merge/revert.
Why this way: Since the root cause (missing `resources`) and the fix (add `resources`) are a 1:1 mapping, there's no reason to bundle in other mgr tuning or unrelated values changes — smaller diffs are easier to bisect if something regresses.

