### PR TITLE
feat: deploy TREK with Authentik SSO and MCP

### DIFF
--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -496,6 +496,24 @@ applications:
     source:
       path: components/default/stirling-pdf
 
+  trek:
+    annotations:
+      argocd.argoproj.io/sync-wave: "20"
+    destination:
+      namespace: default
+    source:
+      path: components/default/trek
+    plugin:
+      env:
+        - name: STORAGE_CLASS
+          value: ceph-block
+        - name: VOLUME_SNAPSHOT_CLASS
+          value: csi-ceph-blockpool
+        - name: VOLSYNC_CAPACITY
+          value: 5Gi
+        - name: VOLSYNC_CACHE_CAPACITY
+          value: 8Gi
+
   synology-photos-backup:
     annotations:
       argocd.argoproj.io/sync-wave: "20"

--- a/components/default/trek/externalsecret.yaml
+++ b/components/default/trek/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: trek
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: trek-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ENCRYPTION_KEY: "{{ .ENCRYPTION_KEY }}"
+        ADMIN_EMAIL: "{{ .ADMIN_EMAIL }}"
+        ADMIN_PASSWORD: "{{ .ADMIN_PASSWORD }}"
+        OIDC_CLIENT_ID: "{{ .CLIENT_ID }}"
+        OIDC_CLIENT_SECRET: "{{ .CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: trek

--- a/components/default/trek/http-route.yaml
+++ b/components/default/trek/http-route.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: &app trek
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+  annotations:
+    gethomepage.dev/href: "https://trek.${CLUSTER_DOMAIN}"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Ingress
+    gethomepage.dev/icon: https://cdn.jsdelivr.net/gh/selfhst/icons/png/trek.png
+spec:
+  parentRefs:
+    - name: ${GATEWAY_NAME}
+      namespace: ${GATEWAY_NAMESPACE}
+      sectionName: https
+  hostnames: ["trek.${CLUSTER_DOMAIN}"]
+  rules:
+    - backendRefs:
+        - name: *app
+          port: 3000

--- a/components/default/trek/kustomization.yaml
+++ b/components/default/trek/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - ./externalsecret.yaml
+  - ./http-route.yaml
+components:
+  - ../../volsync-system/volsync-replication
+
+helmCharts:
+  - name: app-template
+    releaseName: trek
+    namespace: default
+    repo: oci://ghcr.io/bjw-s-labs/helm
+    version: "5.0.1"
+    valuesFile: values.yaml

--- a/components/default/trek/values.yaml
+++ b/components/default/trek/values.yaml
@@ -1,0 +1,102 @@
+---
+defaultPodOptions:
+  securityContext:
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+
+controllers:
+  app:
+    replicas: 1
+    strategy: Recreate
+    pod:
+      annotations:
+        reloader.stakater.com/auto: "true"
+    initContainers:
+      initialize-storage:
+        image:
+          repository: busybox
+          tag: "1.37.0"
+        command: ["sh", "-c", "mkdir -p /storage/data /storage/uploads"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 32Mi
+    containers:
+      app:
+        image:
+          repository: mauriceboe/trek
+          tag: "3.3.0"
+        env:
+          NODE_ENV: production
+          PORT: &port 3000
+          APP_URL: "https://trek.${CLUSTER_DOMAIN}"
+          ALLOWED_ORIGINS: "https://trek.${CLUSTER_DOMAIN}"
+          TRUST_PROXY: "1"
+          FORCE_HTTPS: "true"
+          OIDC_ISSUER: "https://id.${CLUSTER_DOMAIN}/application/o/trek/"
+          OIDC_DISCOVERY_URL: "https://id.${CLUSTER_DOMAIN}/application/o/trek/.well-known/openid-configuration"
+          OIDC_DISPLAY_NAME: Authentik
+          OIDC_SCOPE: "openid email profile groups"
+          OIDC_ADMIN_CLAIM: groups
+          OIDC_ADMIN_VALUE: trek-admins
+        envFrom:
+          - secretRef:
+              name: trek-secret
+        probes:
+          liveness: &healthProbe
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /api/health
+                port: *port
+              initialDelaySeconds: 15
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 3
+          readiness: *healthProbe
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: true
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]
+            add: ["CHOWN", "SETUID", "SETGID"]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 512Mi
+
+service:
+  app:
+    ports:
+      http:
+        port: *port
+
+persistence:
+  storage:
+    existingClaim: trek
+    advancedMounts:
+      app:
+        initialize-storage:
+          - path: /storage
+        app:
+          - path: /app/data
+            subPath: data
+          - path: /app/uploads
+            subPath: uploads
+  tmp:
+    type: emptyDir
+    globalMounts:
+      - path: /tmp

--- a/docs/superpowers/specs/2026-07-14-trek-deployment-design.md
+++ b/docs/superpowers/specs/2026-07-14-trek-deployment-design.md
@@ -1,0 +1,91 @@
+# TREK deployment design
+
+## Goal
+
+Deploy TREK v3.3.0 as a protected, backed-up `default` namespace application at `https://trek.${CLUSTER_DOMAIN}`, with Authentik OIDC sign-in and its built-in MCP endpoint enabled after deployment.
+
+## Scope
+
+- Create a standard application component and Argo CD registration.
+- Persist TREK's SQLite database and uploaded files through the existing VolSync component.
+- Configure Authentik OIDC while retaining one local TREK administrator for recovery.
+- Make the MCP service available at TREK's built-in `/mcp` endpoint.
+
+Not in scope:
+
+- Modifying Authentik itself through GitOps. This repository has no Authentik blueprint/provider-management convention.
+- Deploying an MCP proxy, OAuth gateway, or a second external route.
+- SSO-only login. `OIDC_ONLY` remains unset to prevent an IdP failure from locking operators out of TREK's Admin Panel.
+
+## Selected deployment
+
+Use the existing bjw-s `app-template` convention rather than TREK's upstream Helm chart.
+
+TREK requires separate writable paths at `/app/data` and `/app/uploads`; both contain durable state. The component will use a single Ceph-backed PVC supplied by `volsync-replication`, with an init container creating `data/` and `uploads/` at the PVC root. The main container mounts those paths with `subPath`. One replicated claim therefore protects both state categories without adding a second VolSync implementation.
+
+The controller will run one replica with `Recreate`, which is appropriate for TREK's SQLite database on a ReadWriteOnce volume. It will use `mauriceboe/trek:3.3.0`, expose port 3000, and probe `/api/health`. TREK's entrypoint starts as root to `chown` both mounted paths, then drops to `node` (UID 1000). The container must therefore retain that image-required exception: `runAsNonRoot: false`, `allowPrivilegeEscalation: true`, a writable root filesystem, and only the `CHOWN`, `SETUID`, and `SETGID` capabilities after dropping all others. It will mount an `emptyDir` at `/tmp`.
+
+## Component contract
+
+`components/default/trek/` will contain:
+
+- `kustomization.yaml`: app-template v5.0.1, ExternalSecret, HTTPRoute, and VolSync component.
+- `values.yaml`: TREK image, controller and storage mounts, health checks, resource limits, container security, and non-secret runtime configuration.
+- `externalsecret.yaml`: materializes `trek-secret` from 1Password.
+- `http-route.yaml`: routes `trek.${CLUSTER_DOMAIN}` to service port 3000 and exposes the homepage metadata.
+
+`clusters/talos/apps/20-applications.yaml` will register `trek` at sync wave 20 with `ceph-block`, `csi-ceph-blockpool`, a 5 Gi VolSync primary claim, and the standard cache capacity.
+
+The single HTTPRoute covers HTTP, TREK's `/ws` realtime connection, and `/mcp`; Envoy Gateway routes WebSocket upgrades through the regular backend route. No dedicated route is required.
+
+## Runtime configuration
+
+Non-secret environment values:
+
+- `APP_URL=https://trek.${CLUSTER_DOMAIN}`
+- `ALLOWED_ORIGINS=https://trek.${CLUSTER_DOMAIN}`
+- `TRUST_PROXY=1`
+- `FORCE_HTTPS=true`
+- `OIDC_ISSUER=https://id.${CLUSTER_DOMAIN}/application/o/trek/`
+- `OIDC_DISCOVERY_URL=https://id.${CLUSTER_DOMAIN}/application/o/trek/.well-known/openid-configuration`
+- `OIDC_DISPLAY_NAME=Authentik`
+- `OIDC_SCOPE=openid email profile groups`
+- `OIDC_ADMIN_CLAIM=groups`
+- `OIDC_ADMIN_VALUE=trek-admins`
+
+The 1Password item named `trek` must provide `ENCRYPTION_KEY`, `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `OIDC_CLIENT_ID`, and `OIDC_CLIENT_SECRET`. The bootstrap local administrator exists for recovery; the credentials are never placed in Git.
+
+## Authentik setup
+
+Create an Authentik OAuth2/OpenID provider and application for TREK. Configure:
+
+- Redirect URI: `https://trek.${CLUSTER_DOMAIN}/api/auth/oidc/callback`
+- Client ID and generated client secret: the `trek` 1Password item
+- Scopes: `openid`, `email`, `profile`, and `groups`
+- A dedicated `trek-admins` group emitted in the `groups` claim
+
+The configured group, rather than first login, establishes TREK administrators. Local login stays available if the OIDC provider, callback, or forwarded HTTPS configuration is wrong.
+
+## MCP setup
+
+After both local and Authentik login work, a TREK administrator enables the MCP addon in the Admin Panel. This exposes `https://trek.${CLUSTER_DOMAIN}/mcp`.
+
+TREK, not Authentik, is the MCP OAuth 2.1 authorization server. An MCP client uses dynamic client registration and TREK's consent screen. The browser authentication step uses the authenticated TREK session, which may have been established through Authentik. Static MCP API tokens are excluded because TREK documents them as deprecated.
+
+## Verification
+
+1. Add a focused rendered-manifest test following `scripts/test-ntfy-rendered-manifest.sh`. It must assert the TREK Deployment, Service, HTTPRoute, image, health endpoints, root-entrypoint compatibility (UID 0, writable root filesystem, and exactly the three required capabilities), proxy/CORS environment values, OIDC configuration references, and PVC subpath mounts.
+2. Render the component with `kustomize build --enable-helm` and run that test.
+3. After Argo CD sync, confirm `/api/health` through the public hostname and verify `/ws` realtime updates from two browser sessions.
+4. Verify Authentik redirects to the callback, a member can sign in, and the `trek-admins` group creates a TREK administrator while local recovery login still works.
+5. Enable MCP from the TREK Admin Panel and connect an OAuth 2.1 MCP client to `/mcp`; verify its consent flow and least-privilege scope behavior.
+
+## Sources
+
+- TREK README: https://github.com/mauriceboe/TREK
+- TREK MCP guide: https://github.com/mauriceboe/TREK/blob/main/MCP.md
+- TREK v3.3.0 OIDC callback implementation: https://github.com/mauriceboe/TREK/blob/v3.3.0/server/src/nest/oidc/oidc.controller.ts
+- TREK v3.3.0 container startup contract: https://github.com/mauriceboe/TREK/blob/v3.3.0/Dockerfile
+- Local Authentik client example: `components/default/paperless-ngx/externalsecret.yaml`
+- Local VolSync PVC contract: `components/volsync-system/volsync-replication/pvc.yaml`
+- Local rendered-manifest test convention: `scripts/test-ntfy-rendered-manifest.sh`

--- a/scripts/test-trek-rendered-manifest.sh
+++ b/scripts/test-trek-rendered-manifest.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly TREK_COMPONENT="${ROOT_DIR}/components/default/trek"
+umask 077
+readonly manifest="$(mktemp)"
+trap 'rm -f -- "${manifest}"' EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    exit 1
+}
+
+resource_count() {
+    local kind="$1"
+
+    yq ea -r "[select(.kind == \"${kind}\" and .metadata.name == \"trek\")] | length" "${manifest}"
+}
+
+app_container() {
+    yq ea -r '
+        select(.kind == "Deployment" and .metadata.name == "trek")
+        | .spec.template.spec.containers[]?
+        | select(.image == "mauriceboe/trek:3.3.0")
+    ' "${manifest}"
+}
+app_container_count() {
+  app_container | yq -r '.image'
+}
+
+
+assert_env() {
+    local name="$1"
+    local expected="$2"
+    local actual
+
+    actual="$(NAME="${name}" yq ea -r '
+        select(.kind == "Deployment" and .metadata.name == "trek")
+        | .spec.template.spec.containers[]
+        | select(.image == "mauriceboe/trek:3.3.0")
+        | .env[]
+        | select(.name == env(NAME))
+        | .value
+    ' "${manifest}")"
+    [[ "${actual}" == "${expected}" ]] || fail "${name} must be ${expected}"
+}
+
+kustomize build --enable-helm "${TREK_COMPONENT}" >"${manifest}"
+
+[[ "$(resource_count Deployment)" == "1" ]] || fail "rendered trek Deployment is missing or ambiguous"
+[[ "$(resource_count Service)" == "1" ]] || fail "rendered trek Service is missing or ambiguous"
+[[ "$(resource_count HTTPRoute)" == "1" ]] || fail "rendered trek HTTPRoute is missing or ambiguous"
+[[ "$(resource_count ExternalSecret)" == "1" ]] || fail "rendered trek ExternalSecret is missing or ambiguous"
+[[ "$(app_container_count | wc -l | tr -d ' ')" == "1" ]] || fail "rendered trek container is missing or ambiguous"
+
+assert_env APP_URL 'https://trek.${CLUSTER_DOMAIN}'
+assert_env ALLOWED_ORIGINS 'https://trek.${CLUSTER_DOMAIN}'
+assert_env TRUST_PROXY '1'
+assert_env FORCE_HTTPS 'true'
+assert_env OIDC_DISCOVERY_URL 'https://id.${CLUSTER_DOMAIN}/application/o/trek/.well-known/openid-configuration'
+assert_env OIDC_ADMIN_CLAIM groups
+assert_env OIDC_ADMIN_VALUE trek-admins
+
+[[ "$(app_container | yq -r '.securityContext.runAsUser')" == "0" ]] || fail "TREK must start as UID 0"
+[[ "$(app_container | yq -r '.securityContext.allowPrivilegeEscalation')" == "true" ]] || fail "TREK must permit its gosu handoff"
+[[ "$(app_container | yq -r '.securityContext.readOnlyRootFilesystem')" == "false" ]] || fail "TREK must retain a writable root filesystem"
+[[ "$(app_container | yq -r '.securityContext.capabilities.drop | join(",")')" == "ALL" ]] || fail "TREK must drop all capabilities first"
+[[ "$(app_container | yq -r '.securityContext.capabilities.add | sort | join(",")')" == "CHOWN,SETGID,SETUID" ]] || fail "TREK must retain only chown and gosu capabilities"
+[[ "$(app_container | yq -r '.livenessProbe.httpGet.path')" == "/api/health" ]] || fail "TREK liveness probe must use /api/health"
+[[ "$(app_container | yq -r '.readinessProbe.httpGet.path')" == "/api/health" ]] || fail "TREK readiness probe must use /api/health"
+[[ "$(app_container | yq -r '.volumeMounts[] | select(.mountPath == "/app/data") | .subPath')" == "data" ]] || fail "TREK data mount must use data subpath"
+[[ "$(app_container | yq -r '.volumeMounts[] | select(.mountPath == "/app/uploads") | .subPath')" == "uploads" ]] || fail "TREK uploads mount must use uploads subpath"
+[[ "$(yq ea -r 'select(.kind == "HTTPRoute" and .metadata.name == "trek") | .spec.rules[0].backendRefs[0].port' "${manifest}")" == "3000" ]] || fail "TREK HTTPRoute must target port 3000"
+
+printf 'PASS: rendered TREK deployment, storage, security, OIDC, routing, and probes are consistent\n'


### PR DESCRIPTION
## Summary
- Add a backed-up TREK v3.3.0 deployment using the existing app-template and VolSync patterns.
- Configure Authentik OIDC with a trek-admins group-to-admin mapping while retaining local recovery login.
- Expose TREK HTTP, WebSocket, and built-in MCP OAuth at trek.${CLUSTER_DOMAIN}.
- Register the component with Argo CD at sync wave 20.

## Verification
- bash -n scripts/test-trek-rendered-manifest.sh
- scripts/test-trek-rendered-manifest.sh
- kustomize build --enable-helm components/default/trek
- yq e '.applications.trek' clusters/talos/apps/20-applications.yaml

## Live rollout gate
Do not sync until this branch is merged and the Authentik trek OIDC provider/group plus the 1Password trek item exist. The design spec and implementation plan contain the exact prerequisites.
