### PR TITLE
(fix): pin agent sandbox GitOps manifest

### DIFF
--- a/components/ai/agent-sandbox/kustomization.yaml
+++ b/components/ai/agent-sandbox/kustomization.yaml
@@ -3,4 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: agent-sandbox-system
 resources:
-  - https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/manifest.yaml
+  - https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.2/sandbox-with-extensions.yaml

--- a/docs/superpowers/plans/2026-07-17-agent-sandbox-manifest-repair.md
+++ b/docs/superpowers/plans/2026-07-17-agent-sandbox-manifest-repair.md
@@ -1,0 +1,74 @@
+# Agent Sandbox Manifest Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `executing-plans`.
+
+**Goal:** Restore deterministic Argo CD rendering and kubeconform validation for `agent-sandbox`.
+
+**Architecture:** Replace one invalid floating GitHub release resource with the upstream v0.5.2 all-in-one GitOps asset. The upstream manifest owns the existing `agent-sandbox-system` namespace, so the local Kustomization and Argo CD registration remain unchanged.
+
+**Tech Stack:** Kustomize, kubeconform, Argo CD CMP.
+
+## Global Constraints
+
+- Use the pinned upstream v0.5.2 `sandbox-with-extensions.yaml` asset.
+- Do not modify the namespace, application registration, or controller configuration.
+- Validate with the Argo CD-compatible Kustomize flags and `scripts/kubeconform.sh`.
+
+---
+
+### Task 1: Pin the upstream Agent Sandbox manifest
+
+**Files:**
+- Modify: `components/ai/agent-sandbox/kustomization.yaml:6`
+- Test: direct `kustomize build` of `components/ai/agent-sandbox`; `scripts/kubeconform.sh`
+
+**Interfaces:**
+- Consumes: GitHub release asset `v0.5.2/sandbox-with-extensions.yaml`.
+- Produces: valid Kubernetes manifests in `agent-sandbox-system` for Argo CD and kubeconform.
+
+- [ ] **Step 1: Reproduce the failing render**
+
+Run:
+
+```bash
+kustomize build --load-restrictor LoadRestrictionsNone --enable-exec --enable-alpha-plugins components/ai/agent-sandbox
+```
+
+Expected: non-zero exit with `releases/latest/download/manifest.yaml` resource accumulation failure.
+
+- [ ] **Step 2: Replace the broken resource URL**
+
+Set the sole resource to:
+
+```yaml
+  - https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.2/sandbox-with-extensions.yaml
+```
+
+- [ ] **Step 3: Verify the direct render passes**
+
+Run:
+
+```bash
+kustomize build --load-restrictor LoadRestrictionsNone --enable-exec --enable-alpha-plugins components/ai/agent-sandbox
+```
+
+Expected: zero exit and a rendered `Namespace` named `agent-sandbox-system`.
+
+- [ ] **Step 4: Verify repository manifest validation**
+
+Run:
+
+```bash
+scripts/kubeconform.sh
+```
+
+Expected: zero exit and `All Kubernetes manifest validation completed successfully!`.
+
+- [ ] **Step 5: Commit the repair**
+
+Run:
+
+```bash
+git add components/ai/agent-sandbox/kustomization.yaml docs/superpowers/specs/2026-07-17-agent-sandbox-manifest-design.md docs/superpowers/plans/2026-07-17-agent-sandbox-manifest-repair.md
+git commit -m "(fix): pin agent sandbox GitOps manifest"
+```

--- a/docs/superpowers/specs/2026-07-17-agent-sandbox-manifest-design.md
+++ b/docs/superpowers/specs/2026-07-17-agent-sandbox-manifest-design.md
@@ -1,0 +1,24 @@
+# Agent Sandbox Manifest Repair Design
+
+## Goal
+
+Restore Argo CD manifest generation and kubeconform validation for `agent-sandbox`.
+
+## Scope
+
+Replace the broken floating release resource in `components/ai/agent-sandbox/kustomization.yaml` with the upstream v0.5.2 all-in-one GitOps asset:
+
+`https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.2/sandbox-with-extensions.yaml`
+
+No namespace, application registration, or controller configuration changes are needed.
+
+## Rationale
+
+The current `releases/latest/download/manifest.yaml` path fails Kustomize resolution and references an asset that upstream renamed in v0.5.2. The selected pinned all-in-one asset is upstream's documented GitOps installation path. It includes a `Namespace` named `agent-sandbox-system`, matching the existing Kustomization and Argo CD application destination.
+
+## Validation
+
+- Render `components/ai/agent-sandbox` using the same Kustomize options as Argo CD.
+- Run the existing `scripts/kubeconform.sh` suite.
+
+The pre-change render is the regression reproduction. No dedicated test script is added because the existing component-wide kubeconform path covers this declarative source contract.


### PR DESCRIPTION
## Summary
- replace the floating, renamed Agent Sandbox release asset with the pinned v0.5.2 all-in-one GitOps manifest
- retain the matching agent-sandbox-system namespace

## Validation
- direct Argo-compatible Kustomize render
- targeted kubeconform validation
- repository kubeconform suite reached and passed agent-sandbox before timing out in unrelated later components