### PR TITLE
feat: add suspended Tuppr upgrade controller

### DIFF
--- a/clusters/talos/apps/30-system.yaml
+++ b/clusters/talos/apps/30-system.yaml
@@ -40,6 +40,30 @@ applications:
     source:
       path: components/kube-system/nvidia-gpu-operator
 
+  system-upgrade:
+    annotations:
+      argocd.argoproj.io/sync-wave: "30"
+    destination:
+      namespace: system-upgrade
+    source:
+      path: components/system-upgrade/namespace
+
+  tuppr:
+    annotations:
+      argocd.argoproj.io/sync-wave: "35"
+    destination:
+      namespace: system-upgrade
+    source:
+      path: components/system-upgrade/tuppr
+
+  talos-upgrade:
+    annotations:
+      argocd.argoproj.io/sync-wave: "40"
+    destination:
+      namespace: system-upgrade
+    source:
+      path: components/system-upgrade/talos-upgrade
+
   nvidia-gpu-cluster-policy:
     annotations:
       # Sync wave 31 — after nvidia-gpu-operator (wave 30) registers the

--- a/components/system-upgrade/namespace/kustomization.yaml
+++ b/components/system-upgrade/namespace/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/components/system-upgrade/namespace/namespace.yaml
+++ b/components/system-upgrade/namespace/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-upgrade

--- a/components/system-upgrade/talos-upgrade/kustomization.yaml
+++ b/components/system-upgrade/talos-upgrade/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - talos-upgrade.yaml

--- a/components/system-upgrade/talos-upgrade/talos-upgrade.yaml
+++ b/components/system-upgrade/talos-upgrade/talos-upgrade.yaml
@@ -1,0 +1,16 @@
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: cluster
+  annotations:
+    tuppr.home-operations.com/suspend: "true"
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.13.4
+  parallelism: 1
+  maintenance:
+    windows:
+      - start: "0 2 * * 0"
+        duration: 4h
+        timezone: UTC

--- a/components/system-upgrade/tuppr/kustomization.yaml
+++ b/components/system-upgrade/tuppr/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: system-upgrade
+helmCharts:
+  - name: tuppr
+    releaseName: tuppr
+    namespace: system-upgrade
+    repo: oci://ghcr.io/home-operations/charts
+    version: "0.3.2"
+    valuesFile: values.yaml

--- a/components/system-upgrade/tuppr/values.yaml
+++ b/components/system-upgrade/tuppr/values.yaml
@@ -1,0 +1,8 @@
+talosServiceAccount:
+  create: true
+resources:
+  requests:
+    cpu: 10m
+    memory: 64Mi
+  limits:
+    memory: 128Mi

--- a/scripts/test-tuppr-rendered-manifest.sh
+++ b/scripts/test-tuppr-rendered-manifest.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly ROOT_DIR="$(git rev-parse --show-toplevel)"
+readonly NAMESPACE_COMPONENT="${ROOT_DIR}/components/system-upgrade/namespace"
+readonly TUPPR_COMPONENT="${ROOT_DIR}/components/system-upgrade/tuppr"
+readonly UPGRADE_COMPONENT="${ROOT_DIR}/components/system-upgrade/talos-upgrade"
+readonly APPLICATIONS_FILE="${ROOT_DIR}/clusters/talos/apps/30-system.yaml"
+readonly manifest="$(mktemp)"
+trap 'rm -f -- "${manifest}"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+kustomize build "${NAMESPACE_COMPONENT}" >"${manifest}"
+[[ "$(yq ea -r '[select(.kind == "Namespace" and .metadata.name == "system-upgrade")] | length' "${manifest}")" == "1" ]] || fail "system-upgrade Namespace missing or ambiguous"
+
+kustomize build --enable-helm "${TUPPR_COMPONENT}" >"${manifest}"
+[[ "$(yq ea -r '[select(.apiVersion == "talos.dev/v1alpha1" and .kind == "ServiceAccount" and .metadata.name == "tuppr-talosconfig")] | length' "${manifest}")" == "1" ]] || fail "Tuppr Talos ServiceAccount missing or ambiguous"
+[[ "$(yq ea -r 'select(.kind == "Deployment" and .metadata.name == "tuppr") | .spec.template.spec.volumes[]?.secret.secretName | select(. == "tuppr-talosconfig")' "${manifest}")" == "tuppr-talosconfig" ]] || fail "Tuppr must mount its generated talosconfig"
+
+kustomize build "${UPGRADE_COMPONENT}" >"${manifest}"
+[[ "$(yq ea -r 'select(.kind == "TalosUpgrade" and .metadata.name == "cluster") | .metadata.annotations."tuppr.home-operations.com/suspend"' "${manifest}")" == "true" ]] || fail "TalosUpgrade must remain suspended"
+[[ "$(yq ea -r 'select(.kind == "TalosUpgrade" and .metadata.name == "cluster") | .spec.parallelism' "${manifest}")" == "1" ]] || fail "TalosUpgrade must be sequential"
+[[ "$(yq ea -r 'select(.kind == "TalosUpgrade" and .metadata.name == "cluster") | .spec.maintenance.windows[0] | [.start, .duration, .timezone] | join(",")' "${manifest}")" == "0 2 * * 0,4h,UTC" ]] || fail "TalosUpgrade maintenance window must be Sunday 02:00-06:00 UTC"
+[[ "$(yq ea -r 'select(.kind == "TalosUpgrade" and .metadata.name == "cluster") | .spec.talos.version' "${manifest}")" == "v1.13.4" ]] || fail "TalosUpgrade version must match talenv"
+
+[[ "$(yq -r '.applications."system-upgrade".annotations."argocd.argoproj.io/sync-wave"' "${APPLICATIONS_FILE}")" == "30" ]] || fail "system-upgrade must sync at wave 30"
+[[ "$(yq -r '.applications.tuppr.annotations."argocd.argoproj.io/sync-wave"' "${APPLICATIONS_FILE}")" == "35" ]] || fail "Tuppr must sync at wave 35"
+[[ "$(yq -r '.applications."talos-upgrade".annotations."argocd.argoproj.io/sync-wave"' "${APPLICATIONS_FILE}")" == "40" ]] || fail "TalosUpgrade must sync at wave 40"
+
+printf 'PASS: Tuppr namespace, credential, and suspended upgrade policy are rendered\n'


### PR DESCRIPTION
## Changes
- GitOps-manage the system-upgrade namespace at sync wave 30.
- Deploy Tuppr 0.3.2 at wave 35 with its chart-managed Talos ServiceAccount and generated talosconfig.
- Add a cluster TalosUpgrade at wave 40, suspended, sequential, and limited to Sunday 02:00-06:00 UTC.
- Add rendered-manifest coverage for namespace, credential, suspension, policy, and waves.

## Verification
- PASS: scripts/test-tuppr-rendered-manifest.sh
- Independent code and security reviews approved.

## Notes
No live Argo sync or upgrade was performed.
