### PR TITLE
fix: render Tuppr upgrade CRDs

### DIFF
--- a/components/system-upgrade/tuppr/kustomization.yaml
+++ b/components/system-upgrade/tuppr/kustomization.yaml
@@ -8,3 +8,4 @@ helmCharts:
     repo: oci://ghcr.io/home-operations/charts
     version: "0.3.2"
     valuesFile: values.yaml
+    includeCRDs: true

--- a/scripts/test-tuppr-rendered-manifest.sh
+++ b/scripts/test-tuppr-rendered-manifest.sh
@@ -18,6 +18,7 @@ kustomize build "${NAMESPACE_COMPONENT}" >"${manifest}"
 [[ "$(yq ea -r '[select(.kind == "Namespace" and .metadata.name == "system-upgrade")] | length' "${manifest}")" == "1" ]] || fail "system-upgrade Namespace missing or ambiguous"
 
 kustomize build --enable-helm "${TUPPR_COMPONENT}" >"${manifest}"
+[[ "$(yq ea -r '[select(.kind == "CustomResourceDefinition" and .metadata.name == "talosupgrades.tuppr.home-operations.com")] | length' "${manifest}")" == "1" ]] || fail "TalosUpgrade CRD missing or ambiguous"
 [[ "$(yq ea -r '[select(.apiVersion == "talos.dev/v1alpha1" and .kind == "ServiceAccount" and .metadata.name == "tuppr-talosconfig")] | length' "${manifest}")" == "1" ]] || fail "Tuppr Talos ServiceAccount missing or ambiguous"
 [[ "$(yq ea -r 'select(.kind == "Deployment" and .metadata.name == "tuppr") | .spec.template.spec.volumes[]?.secret.secretName | select(. == "tuppr-talosconfig")' "${manifest}")" == "tuppr-talosconfig" ]] || fail "Tuppr must mount its generated talosconfig"
 


### PR DESCRIPTION
## Fix
- Render Tuppr chart CRDs with Kustomize `includeCRDs: true`.
- Restore the TalosUpgrade CRD required before Argo can apply the existing wave-40 suspended policy.
- Add a focused regression assertion for `talosupgrades.tuppr.home-operations.com`.

## Verification
- Red: `scripts/test-tuppr-rendered-manifest.sh` failed when the CRD was absent.
- Green: the same test passed after the repair.
- Focused strict kubeconform validation passed.
- Independent code review approved.

## Safety
The existing TalosUpgrade remains suspended. No live Argo force-sync or upgrade was performed.
