### PR TITLE
deploy: pin Forge runtime remediation images

### DIFF
--- a/components/ai/forge/values.yaml
+++ b/components/ai/forge/values.yaml
@@ -20,7 +20,7 @@ controllers:
       app:
         image:
           repository: gitea.a113.casa/vpogu/forge
-          tag: 20260717181248-9e1b987
+          tag: 20260717181248-9e1b987@sha256:4371217f79e463849d81428504380e5e2bcb3421cff02b241961ca274243cea7
         env:
           TZ: America/New_York
           FORGE_API_PORT: &httpPort 8080
@@ -32,7 +32,7 @@ controllers:
           FORGE_WORKFLOWS_DIR: /app/config
           FORGE_REPOS_CONFIG: /app/config/repos.yaml
           FORGE_DEFAULT_MODEL: openai/openai/gpt-5.6-terra
-          FORGE_SANDBOX_IMAGE: gitea.a113.casa/vpogu/openshell-sandbox:20260717181335-86a49a8-oci
+          FORGE_SANDBOX_IMAGE: gitea.a113.casa/vpogu/openshell-sandbox:20260717181335-86a49a8-oci@sha256:c82c8abc57eb3e6bb9d3c9cd00846f4cb3b32eb62ec3bd94561febe3440ea351
           FORGE_TOOL_ALLOWLIST: node,python,go,kubectl,kustomize,kubeconform,helm,uv
           FORGE_TOOL_MIRROR_HOSTS: github.com,api.github.com,objects.githubusercontent.com,release-assets.githubusercontent.com,nodejs.org,dl.k8s.io,tuf-repo-cdn.sigstore.dev,pypi.org,files.pythonhosted.org
           FORGE_OTEL_SANDBOX_ENDPOINT: alloy.observability.svc.cluster.local:4318


### PR DESCRIPTION
## Change
- pin Forge orchestrator PR 74 image by digest
- pin OpenShell sandbox runtime UID fix PR 37 image by digest

## Verification
- kustomize/helm render parsed 6 documents
- rendered forge-orchestrator app image exact-matched sha256:4371217f79e463849d81428504380e5e2bcb3421cff02b241961ca274243cea7
- rendered FORGE_SANDBOX_IMAGE exact-matched sha256:c82c8abc57eb3e6bb9d3c9cd00846f4cb3b32eb62ec3bd94561febe3440ea351
- independent rollout review: no findings