### PR TITLE
Allow npm registry sandbox egress

### DIFF
--- a/components/ai/forge/values.yaml
+++ b/components/ai/forge/values.yaml
@@ -34,10 +34,11 @@ controllers:
           FORGE_DEFAULT_MODEL: openai/openai/gpt-5.6-terra
           FORGE_SANDBOX_IMAGE: gitea.a113.casa/vpogu/openshell-sandbox:latest-oci@sha256:4e7a80666b07ecefbb0262664de850edc1e31cc0bb9ae7d8d3e8b541f313f966
           FORGE_TOOL_ALLOWLIST: node,python,go,kubectl,kustomize,kubeconform,helm,uv
-          FORGE_TOOL_MIRROR_HOSTS: github.com,api.github.com,objects.githubusercontent.com,release-assets.githubusercontent.com,nodejs.org,dl.k8s.io,tuf-repo-cdn.sigstore.dev,pypi.org,files.pythonhosted.org,mise-versions.jdx.dev
+          FORGE_TOOL_MIRROR_HOSTS: github.com,api.github.com,objects.githubusercontent.com,release-assets.githubusercontent.com,nodejs.org,dl.k8s.io,tuf-repo-cdn.sigstore.dev,pypi.org,files.pythonhosted.org,mise-versions.jdx.dev,registry.npmjs.org
           FORGE_OTEL_SANDBOX_ENDPOINT: alloy.observability.svc.cluster.local:4318
           FORGE_OTEL_ENDPOINT: http://alloy.observability.svc.cluster.local:4318
           FORGE_NPM_REGISTRY_NODE_PATH: /opt/mise/installs/node/22.22.1/bin/node
+          FORGE_NPM_REGISTRY_HOSTS: registry.npmjs.org
           FORGE_PYPI_REGISTRY_HOSTS: pypi.org,files.pythonhosted.org
           FORGE_SKILLS_CONFIG: /app/config/skills.yaml
           FORGE_RULES_CONFIG: /app/config/rules.yaml

--- a/components/ai/forge/values.yaml
+++ b/components/ai/forge/values.yaml
@@ -38,7 +38,6 @@ controllers:
           FORGE_OTEL_SANDBOX_ENDPOINT: alloy.observability.svc.cluster.local:4318
           FORGE_OTEL_ENDPOINT: http://alloy.observability.svc.cluster.local:4318
           FORGE_NPM_REGISTRY_NODE_PATH: /opt/mise/installs/node/22.22.1/bin/node
-          FORGE_NPM_REGISTRY_HOSTS: registry.npmjs.org
           FORGE_PYPI_REGISTRY_HOSTS: pypi.org,files.pythonhosted.org
           FORGE_SKILLS_CONFIG: /app/config/skills.yaml
           FORGE_RULES_CONFIG: /app/config/rules.yaml


### PR DESCRIPTION
Problem: Forge sandbox npm install fails due to missing registry.npmjs.org in egress allowlist. Changes: Added registry.npmjs.org to FORGE_TOOL_MIRROR_HOSTS in components/ai/forge/values.yaml. Verification: git diff clean, no egress NetworkPolicy blocks host. Pending verification: sandbox npm install and Forge task #154 retry.