### PR TITLE
Split Forge backend and dashboard deployment

### DIFF
--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -613,6 +613,13 @@ applications:
       namespace: ai
     source:
       path: components/ai/forge
+  forge-dashboard:
+    annotations:
+      argocd.argoproj.io/sync-wave: "25"
+    destination:
+      namespace: ai
+    source:
+      path: components/ai/forge-dashboard
 
   agentmemory:
     annotations:

--- a/components/ai/forge-dashboard/http-route.yaml
+++ b/components/ai/forge-dashboard/http-route.yaml
@@ -2,7 +2,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: &app forge-orchestrator
+  name: &app forge-dashboard
   labels:
     app.kubernetes.io/instance: *app
     app.kubernetes.io/name: *app
@@ -13,8 +13,8 @@ metadata:
     gethomepage.dev/icon: https://cdn.jsdelivr.net/gh/selfhst/icons@main/png/secureai-tools.png
     gethomepage.dev/name: Forge
     gethomepage.dev/description: Autonomous dev loop orchestrator
-    gethomepage.dev/app: forge-orchestrator
-    gethomepage.dev/pod-selector: app.kubernetes.io/instance=forge-orchestrator
+    gethomepage.dev/app: forge-dashboard
+    gethomepage.dev/pod-selector: app.kubernetes.io/instance=forge-dashboard
 spec:
   parentRefs:
     - name: ${GATEWAY_NAME}

--- a/components/ai/forge-dashboard/kustomization.yaml
+++ b/components/ai/forge-dashboard/kustomization.yaml
@@ -1,14 +1,12 @@
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ai
 resources:
-  - ./externalsecret.yaml
-  - ./configmap.yaml
-
+  - ./http-route.yaml
 helmCharts:
   - name: app-template
-    releaseName: forge-orchestrator
+    releaseName: forge-dashboard
     namespace: ai
     repo: oci://ghcr.io/bjw-s-labs/helm
     version: "5.0.1"

--- a/components/ai/forge-dashboard/values.yaml
+++ b/components/ai/forge-dashboard/values.yaml
@@ -1,0 +1,60 @@
+---
+controllers:
+  app:
+    replicas: 1
+    strategy: RollingUpdate
+    containers:
+      app:
+        image:
+          repository: gitea.a113.casa/vpogu/forge-dashboard
+          tag: latest-oci
+          pullPolicy: Always
+        env:
+          TZ: America/New_York
+          PORT: &httpPort 3000
+          FORGE_API_URL: http://forge-orchestrator.ai.svc.cluster.local:8080
+        resources:
+          requests:
+            cpu: 10m
+            memory: 128Mi
+          limits:
+            memory: 1Gi
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: *httpPort
+              periodSeconds: 30
+              failureThreshold: 3
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: *httpPort
+              periodSeconds: 10
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: *httpPort
+              initialDelaySeconds: 3
+              periodSeconds: 3
+              failureThreshold: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+    pod:
+      imagePullSecrets:
+        - name: gitea-registry-secret
+service:
+  app:
+    controller: app
+    ports:
+      http:
+        port: *httpPort

--- a/components/ai/forge/values.yaml
+++ b/components/ai/forge/values.yaml
@@ -19,11 +19,12 @@ controllers:
     containers:
       app:
         image:
-          repository: gitea.a113.casa/vpogu/forge
-          tag: 20260719165304-e844a2a
+          repository: gitea.a113.casa/vpogu/forge-backend
+          tag: latest-oci
+          pullPolicy: Always
         env:
           TZ: America/New_York
-          PORT: &httpPort 3000
+          FORGE_API_PORT: &httpPort 8080
           OPENSHELL_GATEWAY_URL: https://openshell:8080
           OPENSHELL_CLIENT_CA_PATH: /etc/openshell-tls/client/ca.crt
           OPENSHELL_CLIENT_CERT_PATH: /etc/openshell-tls/client/tls.crt
@@ -57,7 +58,7 @@ controllers:
             custom: true
             spec:
               httpGet:
-                path: /
+                path: /healthz
                 port: *httpPort
               periodSeconds: 30
               failureThreshold: 3
@@ -66,7 +67,7 @@ controllers:
             custom: true
             spec:
               httpGet:
-                path: /
+                path: /readyz
                 port: *httpPort
               periodSeconds: 10
           startup:
@@ -74,7 +75,7 @@ controllers:
             custom: true
             spec:
               httpGet:
-                path: /
+                path: /readyz
                 port: *httpPort
               initialDelaySeconds: 5
               periodSeconds: 5

--- a/components/argo-system/argocd-image-updater/imageupdater.yaml
+++ b/components/argo-system/argocd-image-updater/imageupdater.yaml
@@ -44,17 +44,32 @@ spec:
             helm:
               name: controllers.app.containers.app.image.repository
               tag: controllers.app.containers.app.image.tag
-    - namePattern: "forge-orchestrator"
+    - namePattern: forge-orchestrator
       writeBackConfig:
         method: "git:secret:argo-system/git-creds"
         gitConfig:
           branch: main
           writeBackTarget: "helmvalues:./values.yaml"
       images:
-        - alias: forge
-          imageName: "gitea.${CLUSTER_DOMAIN}/vpogu/forge"
+        - alias: backend
+          imageName: gitea.${CLUSTER_DOMAIN}/vpogu/forge-backend
           commonUpdateSettings:
-            allowTags: 'regexp:^[0-9]{14}-[a-f0-9]{7}$'
+            allowTags: regexp:^[0-9]{14}-[a-f0-9]{7}-oci$
+          manifestTargets:
+            helm:
+              name: controllers.app.containers.app.image.repository
+              tag: controllers.app.containers.app.image.tag
+    - namePattern: forge-dashboard
+      writeBackConfig:
+        method: "git:secret:argo-system/git-creds"
+        gitConfig:
+          branch: main
+          writeBackTarget: "helmvalues:./values.yaml"
+      images:
+        - alias: dashboard
+          imageName: gitea.${CLUSTER_DOMAIN}/vpogu/forge-dashboard
+          commonUpdateSettings:
+            allowTags: regexp:^[0-9]{14}-[a-f0-9]{7}-oci$
           manifestTargets:
             helm:
               name: controllers.app.containers.app.image.repository


### PR DESCRIPTION
## Summary
- Restore forge-orchestrator as the internal Python backend on port 8080.
- Add the public forge-dashboard Next.js deployment on port 3000.
- Move the Forge HTTPRoute and Homepage metadata to the dashboard.
- Configure Argo CD Image Updater to write immutable OCI timestamp tags for both images.

## Validation
- Parsed backend, dashboard, Image Updater, and application YAML with Ruby.
- Rendered both Helm components with Kustomize.
- Asserted backend Service port 8080 with no HTTPRoute.
- Asserted dashboard Service and HTTPRoute target port 3000.
- Asserted Image Updater writeback targets and timestamp OCI tag selectors.

## Merge order
Do not merge until Forge PR 86 is merged and CI has published both forge-backend:latest-oci and forge-dashboard:latest-oci. These are bootstrap seeds only. Argo CD Image Updater then writes immutable YYYYMMDDHHMMSS-sha-oci tags to values.yaml.