### PR TITLE
Restore Forge sandbox image updater ownership

### DIFF
--- a/components/ai/forge-dashboard/values.yaml
+++ b/components/ai/forge-dashboard/values.yaml
@@ -12,7 +12,6 @@ controllers:
           TZ: America/New_York
           PORT: &httpPort 3000
           FORGE_API_URL: http://forge-orchestrator.ai.svc.cluster.local:8080
-          FORGE_SANDBOX_IMAGE: gitea.a113.casa/vpogu/openshell-sandbox:latest-oci@sha256:4e7a80666b07ecefbb0262664de850edc1e31cc0bb9ae7d8d3e8b541f313f966
         resources:
           requests:
             cpu: 10m

--- a/components/argo-system/argocd-image-updater/imageupdater.yaml
+++ b/components/argo-system/argocd-image-updater/imageupdater.yaml
@@ -59,6 +59,14 @@ spec:
             helm:
               name: controllers.app.containers.app.image.repository
               tag: controllers.app.containers.app.image.tag
+        - alias: openshell-sandbox
+          imageName: "gitea.${CLUSTER_DOMAIN}/vpogu/openshell-sandbox:latest-oci"
+          commonUpdateSettings:
+            updateStrategy: digest
+            forceUpdate: true
+          manifestTargets:
+            helm:
+              spec: controllers.app.containers.app.env.FORGE_SANDBOX_IMAGE
     - namePattern: forge-dashboard
       writeBackConfig:
         method: "git:secret:argo-system/git-creds"
@@ -74,14 +82,6 @@ spec:
             helm:
               name: controllers.app.containers.app.image.repository
               tag: controllers.app.containers.app.image.tag
-        - alias: openshell-sandbox
-          imageName: "gitea.${CLUSTER_DOMAIN}/vpogu/openshell-sandbox:latest-oci"
-          commonUpdateSettings:
-            updateStrategy: digest
-            forceUpdate: true
-          manifestTargets:
-            helm:
-              spec: controllers.app.containers.app.env.FORGE_SANDBOX_IMAGE
     - namePattern: "hermes-agent"
       writeBackConfig:
         method: "git:secret:argo-system/git-creds"


### PR DESCRIPTION
## Summary
- Move the openshell sandbox Image Updater alias back to forge-orchestrator.
- Remove the sandbox environment entry incorrectly written into forge-dashboard values.

## Verification
- Parsed Image Updater and Helm values without emitting sensitive values.
- Asserted backend owns backend and sandbox aliases.
- Asserted dashboard owns only its dashboard alias.
- Rendered backend and dashboard Helm components.

## Impact
Future sandbox digest updates write to the backend workload only.