### PR TITLE
(fix): isolate reactive resume Garage credentials

### DIFF
--- a/components/default/reactive-resume/externalsecret.yaml
+++ b/components/default/reactive-resume/externalsecret.yaml
@@ -13,8 +13,8 @@ spec:
     template:
       engineVersion: v2
       data:
-        STORAGE_ACCESS_KEY: '{{ .MAIN_ACCESS_KEY }}'
-        STORAGE_SECRET_KEY: '{{ .MAIN_SECRET_KEY }}'
+        STORAGE_ACCESS_KEY: "{{ .STORAGE_ACCESS_KEY }}"
+        STORAGE_SECRET_KEY: "{{ .STORAGE_SECRET_KEY }}"
         OPENID_CLIENT_ID: "{{.CLIENT_ID}}"
         OPENID_CLIENT_SECRET: "{{.CLIENT_SECRET}}"
         ACCESS_TOKEN_SECRET: "{{.ACCESS_TOKEN_SECRET}}"
@@ -34,5 +34,3 @@ spec:
         key: reactive-resume
     - extract:
         key: cloudnative-pg
-    - extract:
-        key: garage


### PR DESCRIPTION
## Summary
- source Reactive Resume S3 credentials from its own 1Password item
- stop extracting the shared Garage credential item

## Verification
- kustomize build + kubeconform: 3 valid, 0 invalid/errors, 2 skipped schemas
- rendered ExternalSecret assertion: isolated credential mapping passes
- focused code review: approved, no findings

The isolated Garage key and matching concealed 1Password fields already exist. Reactive Resume remains stopped until this change is merged and reconciled.