### PR TITLE
chore(ivan): drop fitness env + tool grants

### DIFF
--- a/components/ai/forge/configmap.yaml
+++ b/components/ai/forge/configmap.yaml
@@ -33,7 +33,7 @@ data:
           - "cd service && uv run ruff check ."
         test_command: "cd service && uv run pytest && uv run ruff check ."
         format_command: "cd service && uv run ruff format --check ."
-        description: "Ivan personal data service — fitness, bar, drink/dining/travel journals"
+        description: "Ivan personal data service — bar, drink/dining/travel journals"
       forge:
         full_name: vpogu/forge
         instance: gitea-home

--- a/components/ai/hermes-agent/configmap.yaml
+++ b/components/ai/hermes-agent/configmap.yaml
@@ -260,7 +260,6 @@ data:
         - ivan_budget
         - ivan_dining
         - ivan_documents
-        - ivan_fitness
         - ivan_home_assistant
         - ivan_household
         - ivan_journal_images
@@ -291,7 +290,6 @@ data:
         - ivan_budget
         - ivan_dining
         - ivan_documents
-        - ivan_fitness
         - ivan_home_assistant
         - ivan_household
         - ivan_journal_images
@@ -315,7 +313,6 @@ data:
         - ivan_budget
         - ivan_dining
         - ivan_documents
-        - ivan_fitness
         - ivan_home_assistant
         - ivan_household
         - ivan_obsidian
@@ -326,7 +323,6 @@ data:
         - ivan_budget
         - ivan_dining
         - ivan_documents
-        - ivan_fitness
         - ivan_home_assistant
         - ivan_household
         - ivan_obsidian

--- a/components/ai/ivan-personal-service/values.yaml
+++ b/components/ai/ivan-personal-service/values.yaml
@@ -26,12 +26,6 @@ controllers:
           SYNOLOGY_URL: "https://nas.${CLUSTER_DOMAIN}"
           OBSIDIAN_S3_BUCKET: obsidian-notes
           VALKEY_URL: "redis://valkey.default.svc.cluster.local:6379/6"
-          WORKOUT_PLAN_GENERATOR: openai_compatible
-          WORKOUT_PLAN_MODEL: openai/openai/gpt-5.4
-          WORKOUT_PLAN_TEMPERATURE: "0.2"
-          WORKOUT_PLAN_MAX_REPAIR_ATTEMPTS: "2"
-          WORKOUT_VIDEO_RERANKER: openai_compatible
-          WORKOUT_VIDEO_RERANK_MODEL: nvidia/nvidia/Nemotron-3-Nano-30B-A3B
           IMAGE_SEARCH_USER_AGENT: "IvanPersonal/1.0 (https://ivan.${CLUSTER_DOMAIN}; journal image enrichment)"
         envFrom: *envFrom
         resources:


### PR DESCRIPTION
Fitness/workouts was removed from the Ivan service and plugin, so these references now point at nothing.

- **ivan-personal-service**: remove `WORKOUT_PLAN_*` and `WORKOUT_VIDEO_*` env (the service no longer reads them).
- **hermes-agent**: drop the `ivan_fitness` tool grant from every agent allowlist.
- **forge**: drop "fitness" from the ivan service description.

Part of the cross-repo fitness removal (ivan-plugin dashboard/service/plugin + agent-platform hermes crons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)