### PR TITLE
feat: activate Garage backup application

### DIFF
--- a/clusters/talos/apps/20-applications.yaml
+++ b/clusters/talos/apps/20-applications.yaml
@@ -213,6 +213,14 @@ applications:
     source:
       path: components/default/garage-s3
 
+  garage-s3-backup:
+    annotations:
+      argocd.argoproj.io/sync-wave: "20"
+    destination:
+      namespace: default
+    source:
+      path: components/default/garage-s3-backup
+
   home-assistant:
     annotations:
       argocd.argoproj.io/sync-wave: "20"


### PR DESCRIPTION
## Summary
- register the staged garage-s3-backup component in Argo CD
- keep sync CronJob suspended until live baseline verification completes

## Verification
- app-of-apps kustomize render passed
- rendered resources include garage-s3-backup and exclude garage-s3-node2
- strict kubeconform passed
- yamllint passed with the repository document-start warning only