### PR TITLE
Pin models for Forge council roles

### DIFF
--- a/components/ai/forge/configmap.yaml
+++ b/components/ai/forge/configmap.yaml
@@ -64,6 +64,49 @@ data:
         format_command: null
         description: "Home lab GitOps repo — Flux, Helm charts, K8s manifests"
 
+  council.yaml: |-
+    name: council
+    entry_state: todo
+    description: Refine vague todo into an operator-approved specification
+    nodes:
+      - id: analyze
+        type: agent
+        role: council-analyst
+        read_only: true
+        model: nvidia/nvidia/Nemotron-3-Nano-30B-A3B
+        verify:
+          - "git diff --exit-code && git diff --cached --exit-code"
+      - id: investigate
+        type: agent
+        role: council-investigator
+        read_only: true
+        model: openai/openai/gpt-5.6-terra
+        verify:
+          - "git diff --exit-code && git diff --cached --exit-code"
+        depends_on: [analyze]
+      - id: critique
+        type: agent
+        role: council-critic
+        read_only: true
+        model: aws/anthropic/bedrock-claude-sonnet-4-6
+        verify:
+          - "git diff --exit-code && git diff --cached --exit-code"
+        depends_on: [analyze, investigate]
+      - id: decide
+        type: agent
+        role: council-judge
+        read_only: true
+        model: aws/anthropic/bedrock-claude-opus-4-8
+        verify:
+          - "git diff --exit-code && git diff --cached --exit-code"
+        depends_on: [analyze, investigate, critique]
+      - id: council-approval
+        type: approval
+        on_approve:
+          state: ready
+          workflow: feature
+        depends_on: [decide]
+
   feature.yaml: |-
     # Deployment override of the bundled gated workflow: same structure, plus
     # model pins (FORGE_WORKFLOWS_DIR wins over the image-bundled copy).


### PR DESCRIPTION
## Summary
- add a deployment-controlled `council.yaml` workflow override
- pin distinct models for analyst, investigator, critic, and judge roles

## Verification
- `yamllint -c .yamllint.yaml components/ai/forge/configmap.yaml`
- rendered `forge-config` contains all four expected role/model pairs
- focused configuration review approved

## Note
- full repository kubeconform was started but exceeded the harness command deadline; direct Forge rendering succeeded. Its ExternalSecret is skipped because no local schema is installed.