### PR TITLE
fix(garage): recover metadata from snapshot and cut to sqlite

### DIFF
--- a/components/default/garage-s3/resources/configuration.toml
+++ b/components/default/garage-s3/resources/configuration.toml
@@ -5,8 +5,9 @@ data_dir = [
   { path = "/storage/data", capacity = "3TB" },
 ]
 
-db_engine = "lmdb"
-metadata_auto_snapshot_interval = "6h"
+db_engine = "sqlite"
+metadata_fsync = true
+metadata_auto_snapshot_interval = "1h"
 
 replication_factor = 1
 

--- a/components/default/garage-s3/values.yaml
+++ b/components/default/garage-s3/values.yaml
@@ -3,7 +3,9 @@ controllers:
   garage-s3:
     annotations:
       reloader.stakater.com/auto: "true"
+    strategy: Recreate
     pod:
+      terminationGracePeriodSeconds: 120
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -13,6 +15,26 @@ controllers:
                     operator: In
                     values:
                       - k8s-3-4u
+    initContainers:
+      verify-storage:
+        image:
+          repository: public.ecr.aws/docker/library/busybox
+          tag: "1.38.0"
+        command:
+          - /bin/sh
+          - -c
+          - test -s /storage/meta/node_key && test -s /storage/meta/db.sqlite && test -d /storage/data
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: 5m
+            memory: 8Mi
+          limits:
+            memory: 16Mi
     containers:
       app:
         image:
@@ -87,7 +109,7 @@ persistence:
   storage:
     type: hostPath
     hostPath: /var/mnt/backup-garage/garage-single
-    hostPathType: DirectoryOrCreate
+    hostPathType: Directory
     globalMounts:
       - path: /storage
 

--- a/components/default/synology-photos-backup/cronjob.yaml
+++ b/components/default/synology-photos-backup/cronjob.yaml
@@ -4,6 +4,7 @@ metadata:
   name: &app synology-backup
   namespace: default
 spec:
+  suspend: true
   schedule: "0 2 * * 0"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Recovery

- Isolates LMDB DB and migrates verified 06:12:37Z catalog snapshot to SQLite
- Requires  and SQLite to exist before allowing start
- Disallows DirectoryOrCreate on the XFS mount to prevent silent resets
- Adopts Recreate strategy and 120s grace period
- Suspends Synology copy; Kopia already resumed live