### PR TITLE
(fix): prevent stale backup catch-up jobs

### DIFF
--- a/components/default/garage-s3-backup/sync-cronjob.yaml
+++ b/components/default/garage-s3-backup/sync-cronjob.yaml
@@ -8,6 +8,7 @@ spec:
   schedule: "0 4 * * *"
   timeZone: America/New_York
   concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
   suspend: false
   jobTemplate:
     spec:

--- a/components/default/garage-s3-backup/sync-cronjob.yaml
+++ b/components/default/garage-s3-backup/sync-cronjob.yaml
@@ -8,7 +8,7 @@ spec:
   schedule: "0 4 * * *"
   timeZone: America/New_York
   concurrencyPolicy: Forbid
-  startingDeadlineSeconds: 300
+  startingDeadlineSeconds: 7200
   suspend: false
   jobTemplate:
     spec:

--- a/components/default/synology-photos-backup/cronjob.yaml
+++ b/components/default/synology-photos-backup/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   suspend: false
   schedule: "0 2 * * 0"
-  startingDeadlineSeconds: 300
+  startingDeadlineSeconds: 7200
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/components/default/synology-photos-backup/cronjob.yaml
+++ b/components/default/synology-photos-backup/cronjob.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   suspend: false
   schedule: "0 2 * * 0"
+  startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid


### PR DESCRIPTION
Adds a two-hour missed-run deadline to the Synology and Garage backup CronJobs. Resuming after a multi-hour or multi-day pause will not launch stale catch-up Jobs, while ordinary scheduled runs can still recover from short node upgrades or outages. Existing concurrencyPolicy: Forbid remains unchanged.